### PR TITLE
新規ユーザー登録画面のマークアップおよびスタイリング(3/7ページ目)

### DIFF
--- a/app/assets/stylesheets/_users_registration.scss
+++ b/app/assets/stylesheets/_users_registration.scss
@@ -67,6 +67,9 @@
     bottom: 7px;
     left: 50%;
   }
+  &--active {
+    background-color: #ea362e;
+  }
 }
 
 .registration-main {
@@ -187,6 +190,7 @@
       border-radius: 0;
       margin: 24px 0 0 0;
       border: none;
+      cursor: pointer;
       &:hover {
         opacity: inherit;
       }

--- a/app/assets/stylesheets/_users_sms_confirmation.scss
+++ b/app/assets/stylesheets/_users_sms_confirmation.scss
@@ -1,0 +1,11 @@
+.sms_confirmation {
+  color: #333;
+  font-family: "Source Sans Pro", Helvetica, Arial, 游ゴシック体, YuGothic,
+    メイリオ, Meiryo, sans-serif;
+  &__form {
+    &__text {
+      font-size: 14px;
+      margin: 8px 0 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,2 +1,3 @@
 @import "users_signup";
 @import "users_registration";
+@import "users_sms_confirmation";

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,9 @@ class UsersController < ApplicationController
   def registration
   end
 
+  def sms_confirmation
+  end
+
   def mypage_profile    
   end
 end

--- a/app/views/users/sms_confirmation.html.haml
+++ b/app/views/users/sms_confirmation.html.haml
@@ -1,0 +1,58 @@
+.registration-container
+  %header.registration-header
+    %h1
+      %a(href="/" class="registration-header__logo")
+        = image_tag 'mercari_logo_horizontal', class: 'registration-header__logo--img'
+    %nav.registration-header__progress-bar
+      %ol
+        %li
+          会員情報
+          .registration-header__progress-status.registration-header__progress-status--active
+          .progress-status__bar.progress-status__bar--after.progress-status__bar--active
+        %li.registration-header--active
+          電話番号認証
+          .progress-status__bar.progress-status__bar--before.progress-status__bar--active
+          .registration-header__progress-status.registration-header__progress-status--active
+          .progress-status__bar.progress-status__bar--after
+        %li
+          お届け先住所入力
+          .progress-status__bar.progress-status__bar--before
+          .registration-header__progress-status
+          .progress-status__bar.progress-status__bar--after
+        %li
+          支払い方法
+          .progress-status__bar.progress-status__bar--before
+          .registration-header__progress-status
+          .progress-status__bar.progress-status__bar--after
+        %li
+          完了
+          .progress-status__bar.progress-status__bar--before
+          .registration-header__progress-status
+  %main.registration-main
+    .registration-main__container
+      %h2 電話番号の確認
+      =form_for :user, html: { class: "registration-main__form" } do |f|
+        .registration-main__form__content
+          .registration-main__form__group
+            = f.label :phone_number, "携帯電話の番号"
+            = f.phone_field :phone_number, class: "registration-main__form__input", placeholder: "携帯電話の番号を入力"
+          %p.sms_confirmation__form__text
+            本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用して認証を行います。
+          = f.submit class: "signup__form__btn signup__form__btn--mail registration-main__form__next-btn", value: "SMSを送信する"
+          %p.sms_confirmation__form__text
+            ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
+          .registration-main__form__about-text
+            %a(href="/") 電話番号の確認が必要な理由＞
+  %footer.signup__footer
+    .signup__footer__nav
+      %ul.signup__footer__nav__links
+        %li
+          %a{href: "/", class: "signup__footer__nav__link"} プライバシーポリシー
+        %li
+          %a{href: "/", class: "signup__footer__nav__link"} メルカリ利用規約
+        %li
+          %a{href: "/", class: "signup__footer__nav__link"} 特定商取引に関する表記
+      %a(href="/")
+        = image_tag 'mercari_logo_vertical', class: 'signup__footer__nav__logo'
+      %p.signup__footer__nav__text
+        © 2019 Mercari

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   get 'users/mypage_profile' => 'users#mypage_profile'
   get "/users/signup" => "users#signup"
   get "/users/signup/registration" => "users#registration"
+  get "/users/signup/sms_confirmation" => "users#sms_confirmation"
 end


### PR DESCRIPTION
# What  
新規ユーザー登録画面 3ページ目のマークアップを行なった。

## 備考
ほとんど2ページ目と同様でしたので、使い回しで完了しました。
![users_sms_confirmation](https://user-images.githubusercontent.com/52557788/62441935-10b5c680-b791-11e9-9f6f-bf7bc5cae421.png)

以下、オリジナル
![電話番号の確認 - メルカリ](https://user-images.githubusercontent.com/52557788/62441946-190e0180-b791-11e9-8f6b-e2ea635b2ab2.png)
