### PR TITLE
ログインページのマークアップ

### DIFF
--- a/app/assets/stylesheets/_users_login.scss
+++ b/app/assets/stylesheets/_users_login.scss
@@ -1,0 +1,96 @@
+.login-header {
+  height: 128px;
+  background-color: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &__logo {
+    width: 230px;
+  }
+}
+.login-main {
+  background-color: #f5f5f5;
+  color: #333;
+  font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic",
+    "メイリオ", "Meiryo", sans-serif;
+}
+.login-panel {
+  background-color: #fff;
+  width: 456px;
+  margin: 0 auto;
+}
+.login {
+  &__new-account {
+    font-size: 14px;
+    padding: 40px 64px;
+    border-bottom: 1px solid #eee;
+    text-align: center;
+    &__btn {
+      display: block;
+      margin: 8px 0 0;
+      border: 1px solid #0099e8;
+      background: #0099e8;
+      color: #fff;
+      line-height: 40px;
+    }
+  }
+  &__external-account {
+    font-size: 14px;
+    padding: 32px 64px;
+    &__btn {
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      text-align: center;
+      &--facebook {
+        background-color: #385185;
+        color: #fff;
+      }
+      &--google {
+        margin-top: 16px;
+        border: #979797 solid 1px;
+        color: #333;
+      }
+    }
+  }
+  &__form {
+    padding: 24px 64px 32px;
+    &__input {
+      box-sizing: border-box;
+      width: 100%;
+      height: 48px;
+      padding: 10px 16px 8px;
+      margin-bottom: 15px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      background: #fff;
+      line-height: 1.5;
+      font-size: 16px;
+    }
+    &__recaptcha-img {
+      width: 300px;
+    }
+    &__submit-btn {
+      background: #ea352d;
+      border: 1px solid #ea352d;
+      color: #fff;
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      cursor: pointer;
+      text-align: center;
+      margin-top: 24px;
+    }
+    &__forgot-pass-text {
+      display: block;
+      font-size: 14px;
+      padding-top: 40px;
+      color: #0099e8;
+      text-decoration: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -3,5 +3,6 @@
 @import "users_sms_confirmation";
 @import "users_address";
 @import "users_card";
+@import "users_login";
 @import "mypage_identification";
 @import "l-side";

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,9 @@ class UsersController < ApplicationController
   def signup
   end
 
+  def login
+  end
+
   def registration
   end
 

--- a/app/views/users/login.html.haml
+++ b/app/views/users/login.html.haml
@@ -1,0 +1,37 @@
+%header.login-header
+  %h1.login-header__head
+    %a(href="/")
+      = image_tag 'mercari_logo_horizontal.png', class: 'login-header__logo'
+%main.login-main
+  .login-panel
+    .login__new-account
+      %p
+        アカウントをお持ちでない方はこちら
+      %a(href="/" class="login__new-account__btn")
+        新規会員登録
+    .login__external-account
+      %a(href="/" class="login__external-account__btn login__external-account__btn--facebook")
+        Facebookでログイン
+      %a(href="/" class="login__external-account__btn login__external-account__btn--google")
+        Googleでログイン
+    .login__form
+      = form_for :user do |f|
+        = f.email_field :email, placeholder: "メールアドレス", class: "login__form__input"
+        = f.password_field :password, placeholder: "パスワード", class: "login__form__input"
+        = image_tag 'recaptcha.jpeg', class: 'login__form__recaptcha-img'
+        = f.submit class: "login__form__submit-btn", value: "ログイン"
+      %a(href="/" class="login__form__forgot-pass-text")
+        パスワードをお忘れの方
+%footer.signup__footer
+  .signup__footer__nav
+    %ul.signup__footer__nav__links
+      %li
+        %a{href: "/", class: "signup__footer__nav__link"} プライバシーポリシー
+      %li
+        %a{href: "/", class: "signup__footer__nav__link"} メルカリ利用規約
+      %li
+        %a{href: "/", class: "signup__footer__nav__link"} 特定商取引に関する表記
+    %a(href="/")
+      = image_tag 'mercari_logo_vertical', class: 'signup__footer__nav__logo'
+    %p.signup__footer__nav__text
+      © 2019 Mercari

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
   get "/users/signup/sms_authentication" => "users#sms_authentication" 
   get "/users/signup/address" => "users#address" 
   get "/users/signup/payment" => "users#payment" 
-  get "/users/signup/complete" => "users#complete" 
+  get "/users/signup/complete" => "users#complete"
+  get "/users/login" => "users#login"
   get "/mypage/identification/"=> "users#identification" 
   get "/mypage/logout/"=> "users#logout" 
 


### PR DESCRIPTION
# What 
ログインページのマークアップを実施した。

## 備考
- Facebook, Googleアカウントでのログインボタンのアイコンは保留。後ほど導入する。
- reCAPTCHAのパーツは、現時点では画像を仮置きしています。
![users_login](https://user-images.githubusercontent.com/52557788/62525950-3fa46900-b873-11e9-977e-65b0120ca96a.png)

以下、オリジナル
![ログイン - メルカリ](https://user-images.githubusercontent.com/52557788/62525965-492dd100-b873-11e9-856a-eb49e42b4743.png)
