### PR TITLE
[WIP] SNS認証によるユーザー登録機能の実装

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,8 +18,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: provider.capitalize)
       sign_in_and_redirect @user, event: :authentication
     else
-      session["devise.#{provider}_data"] = request.env['omniauth.auth']
-      redirect_to new_user_registration_url
+      session[:uid] = request.env['omniauth.auth'][:uid]
+      session[:provider] = provider
+      session[:nickname] = request.env['omniauth.auth']["info"][:name]
+      session[:email] = request.env['omniauth.auth']["info"][:email]
+      redirect_to users_signup_registration_path
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,10 @@ class UsersController < ApplicationController
 
   def registration
     @user = User.new
+    @nickname = session[:nickname]
+    @email = session[:email]
+    session.delete(:nickname)
+    session.delete(:email)
   end
 
   def confirmation
@@ -42,6 +46,14 @@ class UsersController < ApplicationController
   def create
     @user = User.new(session[:user_params])
     @address = Address.new(session[:address_params].merge(user: @user))
+
+    if session[:provider]
+      @user.sns_credentials.create(
+        provider: session[:provider],
+        uid: session[:uid]
+      )
+    end
+
     if @user.save && @address.save  
       reset_session
       sign_in(@user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,13 +48,13 @@ class UsersController < ApplicationController
     @address = Address.new(session[:address_params].merge(user: @user))
 
     if session[:provider]
-      @user.sns_credentials.create(
+      @user.sns_credentials.new(
         provider: session[:provider],
         uid: session[:uid]
       )
     end
 
-    if @user.save && @address.save  
+    if @user.save && @address.save
       reset_session
       sign_in(@user)
       redirect_to users_signup_complete_path

--- a/app/views/users/registration.html.haml
+++ b/app/views/users/registration.html.haml
@@ -42,7 +42,8 @@
             %span.registration__form--require 必須
             = f.text_field :nickname,
               class: "registration__form__input",
-              placeholder: "例) メルカリ太郎"
+              placeholder: "例) メルカリ太郎",
+              value: @nickname
             = render 'error_messages',
               errors: @user.errors.full_messages_for(:nickname)
           .registration__form__group
@@ -50,7 +51,8 @@
             %span.registration__form--require 必須
             = f.email_field :email,
               class: "registration__form__input",
-              placeholder: "PC・携帯どちらでも可"
+              placeholder: "PC・携帯どちらでも可",
+              value: @email
             = render 'error_messages',
               errors: @user.errors.full_messages_for(:email)
           .registration__form__group

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -265,7 +265,8 @@ Devise.setup do |config|
                                Rails.application.secrets[:FACEBOOK_SECRET]
   
     config.omniauth :google_oauth2, Rails.application.secrets[:GOOGLE_ID],
-                                    Rails.application.secrets[:GOOGLE_SECRET]
+                                    Rails.application.secrets[:GOOGLE_SECRET],
+                                    skip_jwt: true
   end
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
## What 
SNS認証(Facebook or Google)によるユーザー登録機能を実装した。

## Why 
- コピー元のメルカリに実装されている機能であるため。
- ユーザー登録の手間を省くことが出来るため。

### 詳細
- 既に実装されていたomniauthによるSNS情報の取得機能を利用した。
- 各SNSから取得した情報をセッションに格納し、新規登録の完了時に、それらの情報がsns_credentialsテーブルに保存される。
- 単体テストは未実装 (今後書く予定)