### PR TITLE
【WIP】商品出品ページに発送元の都道府県を反映

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -81,7 +81,7 @@ class ProductsController < ApplicationController
   private
   def product_params
     params.require(:product).permit(:product_name, :description, :first_category_id, :second_category_id, :third_category_id, :condition, :delivery_charge, :delivery_way, :delivery_date,:price,
-      :order_status, images_attributes: [ :image, :_destroy, :id ])   
+      :order_status, :prefecture_id, images_attributes: [ :image, :_destroy, :id ])   
   end
   
   def set_Category

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -67,7 +67,8 @@
                   %label
                     発送元の地域
                     %span.form-require 必須
-                  = select_tag "prefecture", options_for_select({北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,岐阜県:21,静岡県:22,愛知県:23,三重県:24,滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,徳島県:36,香川県:37,愛媛県:38,高知県:39,福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,沖縄県:47}), class:"registration__form__input"
+                  .select-wrap
+                    = f.collection_select :prefecture_id, Prefecture.all, :id, :name, { class: 'registration__form__input' }
                 .form-group
                   %label
                     発送までの日数

--- a/db/migrate/20190821050433_add_prefecture_id_to_products.rb
+++ b/db/migrate/20190821050433_add_prefecture_id_to_products.rb
@@ -1,0 +1,5 @@
+class AddPrefectureIdToProducts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :products, :prefecture_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190818033515) do
+ActiveRecord::Schema.define(version: 20190821050433) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string  "postal_code",      null: false
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20190818033515) do
     t.integer "third_category_id"
     t.integer "brand_id"
     t.integer "size_id"
+    t.integer "prefecture_id",                    null: false
     t.index ["brand_id"], name: "index_products_on_brand_id", using: :btree
     t.index ["first_category_id"], name: "index_products_on_first_category_id", using: :btree
     t.index ["second_category_id"], name: "index_products_on_second_category_id", using: :btree


### PR DESCRIPTION
# What
active hashを用いて都道府県を選択、データとして格納可能にした。


# Why
商品詳細欄で発送元(都道府県)を表示するため。