### PR TITLE
[WIP] 購入完了ページ実装、ならびに購入した商品にタグ付け&再購入不可能に

### DIFF
--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -83,7 +83,7 @@ $color-red: #ea362e;
     outline: none;
   }
 
-  &:active {
+  &.active {
     background: $color-black;
     opacity: 1;
   }

--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -213,4 +213,8 @@ $color-red: #ea362e;
     top: 35px;
     z-index: 10;
   }
+
+  &--search {
+    bottom: 230px;
+  }
 }

--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -202,8 +202,8 @@ $color-red: #ea362e;
   margin-bottom: -130px;
   position: relative;
   right: 65px;
-  width: 65px;
   transform: rotate(-45deg);
+  width: 65px;
 
   &__text {
     color: $color-white;

--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -192,10 +192,10 @@ $color-red: #ea362e;
 }
 
 .tag-sold {
-  border-top: 65px solid transparent;
-  border-right: 65px solid transparent;
   border-bottom: 65px solid $color-red;
   border-left: 65px solid transparent;
+  border-right: 65px solid transparent;
+  border-top: 65px solid transparent;
   bottom: 280px;
   box-sizing: border-box;
   height: 65px;

--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -190,3 +190,27 @@ $color-red: #ea362e;
   text-align: right;
   width: 100%;
 }
+
+.tag-sold {
+  border-top: 65px solid transparent;
+  border-right: 65px solid transparent;
+  border-bottom: 65px solid $color-red;
+  border-left: 65px solid transparent;
+  bottom: 280px;
+  box-sizing: border-box;
+  height: 65px;
+  margin-bottom: -130px;
+  position: relative;
+  right: 65px;
+  width: 65px;
+  transform: rotate(-45deg);
+
+  &__text {
+    color: $color-white;
+    font-size: 23px;
+    position: relative;
+    right: 32px;
+    top: 35px;
+    z-index: 10;
+  }
+}

--- a/app/assets/stylesheets/_products_confirm.scss
+++ b/app/assets/stylesheets/_products_confirm.scss
@@ -3,7 +3,7 @@ $color-white: #fff;
 $color-light-gray: #ccc;
 $color-red: #ea352d;
 $color-gray: #888;
-$color-bg-yellow: #FFF6CF;
+$color-bg-yellow: #fff6cf;
 
 .confirm-main {
   background-color: $color-bg-gray;
@@ -47,8 +47,8 @@ $color-bg-yellow: #FFF6CF;
   &__price {
     font-size: 22px;
     font-weight: bold;
+    margin: 15px 0 0;
     text-align: center;
-    margin: 15px 0 0 0;
     width: 100%;
   }
 
@@ -122,7 +122,7 @@ $color-bg-yellow: #FFF6CF;
 }
 
 .confirm-address {
-  margin: 8px 0 0 0;
+  margin: 8px 0 0;
 
   &__head {
     font-weight: bold;
@@ -132,8 +132,8 @@ $color-bg-yellow: #FFF6CF;
 .confirm-link {
   text-align: right;
 
-    &:hover {
-    opacity: 0.7;
+  &:hover {
+    opacity: .7;
     text-decoration: underline;
   }
 }
@@ -170,7 +170,7 @@ $color-bg-yellow: #FFF6CF;
 .complete-item {
   border-bottom: 1px solid $color-bg-gray;
   text-align: center;
-  
+
   &__image {
     padding: 8px;
     width: 160px;
@@ -197,8 +197,8 @@ $color-bg-yellow: #FFF6CF;
 .complete-text-left {
   border-bottom: 1px solid $color-bg-gray;
   margin: 0 auto;
-  width: 320px;
   padding: 26px 0 32px;
+  width: 320px;
 }
 
 .complete-text-bold {
@@ -219,5 +219,18 @@ $color-bg-yellow: #FFF6CF;
 
 .complete-icons {
   padding: 10px 0 0;
+
+  &-wink {
+    color: #ef5185;
+  }
+
+  &-meh {
+    color: #fbaa34;
+  }
+
+  &-frown {
+    color: #69b5d8;
+  }
 }
+
 

--- a/app/assets/stylesheets/_products_confirm.scss
+++ b/app/assets/stylesheets/_products_confirm.scss
@@ -3,11 +3,7 @@ $color-white: #fff;
 $color-light-gray: #ccc;
 $color-red: #ea352d;
 $color-gray: #888;
-
-
-.confirm-header {
-  background-color: $color-bg-gray;
-}
+$color-bg-yellow: #FFF6CF;
 
 .confirm-main {
   background-color: $color-bg-gray;
@@ -141,3 +137,87 @@ $color-gray: #888;
     text-decoration: underline;
   }
 }
+
+.complete-alert {
+  background-color: $color-bg-yellow;
+  border-bottom: 1px solid $color-bg-gray;
+  padding: 22px 16px;
+
+  &-head {
+    align-items: center;
+    color: $color-red;
+    display: flex;
+    font-size: 16px;
+    font-weight: bold;
+    justify-content: center;
+    padding: 0 0 16px;
+  }
+
+  &-text {
+    text-align: center;
+  }
+}
+
+.complete-head {
+  border-bottom: 1px solid $color-bg-gray;
+  font-size: 22px;
+  font-weight: bold;
+  line-height: 1.5;
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.complete-item {
+  border-bottom: 1px solid $color-bg-gray;
+  text-align: center;
+  
+  &__image {
+    padding: 8px;
+    width: 160px;
+  }
+
+  &__text {
+    font-size: 16px;
+    font-weight: bold;
+    padding: 5px 0 20px;
+  }
+}
+
+.complete-text-center {
+  border-bottom: 1px solid $color-bg-gray;
+  padding: 32px;
+  text-align: center;
+}
+
+.complete-price-text {
+  font-size: 22px;
+  font-weight: bold;
+}
+
+.complete-text-left {
+  border-bottom: 1px solid $color-bg-gray;
+  margin: 0 auto;
+  width: 320px;
+  padding: 26px 0 32px;
+}
+
+.complete-text-bold {
+  font-size: 16px;
+  font-weight: bold;
+  padding: 0 0 16px;
+}
+
+.complete-link-text {
+  display: block;
+  font-weight: bold;
+  padding: 16px 0 0;
+}
+
+.complete-text {
+  line-height: 1.5;
+}
+
+.complete-icons {
+  padding: 10px 0 0;
+}
+

--- a/app/assets/stylesheets/_products_confirm.scss
+++ b/app/assets/stylesheets/_products_confirm.scss
@@ -4,6 +4,9 @@ $color-light-gray: #ccc;
 $color-red: #ea352d;
 $color-gray: #888;
 $color-bg-yellow: #fff6cf;
+$color-pink: #ef5185;
+$color-orange: #fbaa34;
+$color-blue: #69b5d8;
 
 .confirm-main {
   background-color: $color-bg-gray;
@@ -221,16 +224,14 @@ $color-bg-yellow: #fff6cf;
   padding: 10px 0 0;
 
   &-wink {
-    color: #ef5185;
+    color: $color-pink;
   }
 
   &-meh {
-    color: #fbaa34;
+    color: $color-orange;
   }
 
   &-frown {
-    color: #69b5d8;
+    color: $color-blue;
   }
 }
-
-

--- a/app/assets/stylesheets/_products_confirm.scss
+++ b/app/assets/stylesheets/_products_confirm.scss
@@ -2,6 +2,7 @@ $color-bg-gray: #f5f5f5;
 $color-white: #fff;
 $color-light-gray: #ccc;
 $color-red: #ea352d;
+$color-gray: #888;
 
 
 .confirm-header {
@@ -107,9 +108,9 @@ $color-red: #ea352d;
 }
 
 .btn-disabled {
-  background: #888;
-  border: 1px solid #888;
-  color: #fff;
+  background: $color-gray;
+  border: 1px solid $color-gray;
+  color: $color-white;
   cursor: not-allowed;
 }
 

--- a/app/assets/stylesheets/_products_confirm.scss
+++ b/app/assets/stylesheets/_products_confirm.scss
@@ -1,134 +1,142 @@
-.products-confirm {
-  color: #333;
-  font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic",
-    "メイリオ", "Meiryo", sans-serif;
-  background-color: #f5f5f5;
-  &__header {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 128px;
-    &__logo {
-      width: 230px;
-    }
+$color-bg-gray: #f5f5f5;
+$color-white: #fff;
+$color-light-gray: #ccc;
+$color-red: #ea352d;
+
+
+.confirm-header {
+  background-color: $color-bg-gray;
+}
+
+.confirm-main {
+  background-color: $color-bg-gray;
+
+  &__container {
+    background-color: $color-white;
+    margin: 0 auto;
+    width: 700px;
   }
-  &__main {
-    &__container {
-      width: 700px;
-      background-color: #fff;
-      margin: 0 auto;
-    }
-    &__head {
-      font-size: 22px;
-      padding: 16px;
-      font-weight: bold;
-      text-align: center;
-      border-bottom: 1px solid #f5f5f5;
-    }
-    &__item {
-      padding: 24px 12.5% 0;
-    }
-    &--inner {
-      width: 320px;
-      margin: 0 auto;
-    }
-  }
+}
+
+.confirm-head {
+  border-bottom: 1px solid $color-bg-gray;
+  font-size: 22px;
+  font-weight: bold;
+  padding: 16px;
+  text-align: center;
+}
+
+.confirm-content {
+  padding: 24px 12.5% 0;
+}
+
+.confirm-item {
+  margin: 0 auto;
+  width: 320px;
+
   &__image {
     height: 64px;
     width: 64px;
   }
-  &__product-name {
-    font-size: 16px;
+
+  &__name {
     float: right;
-    width: 240px;
+    font-size: 16px;
     font-weight: 600;
     line-height: 1.5;
+    width: 240px;
   }
-  &__product-price {
+
+  &__price {
     font-size: 22px;
     font-weight: bold;
-    width: 100%;
     text-align: center;
-    margin-top: 8px;
-    &--shipment-fee {
-      font-size: 14px;
-      margin-left: 8px;
-      font-weight: 400;
-    }
+    margin: 15px 0 0 0;
+    width: 100%;
   }
-  &__users-point {
-    &--none {
-      font-size: 14px;
-      text-align: center;
-      box-sizing: border-box;
-      height: 48px;
-      line-height: 48px;
-      margin-top: 16px;
-      border: 1px solid #ccc;
-      background-color: #cccccc;
-    }
+
+  &__shipment-fee {
+    font-size: 14px;
+    font-weight: 400;
+    margin-left: 8px;
   }
-  &__buy-price-label {
+
+  &__point {
+    background-color: $color-light-gray;
+    border: 1px solid $color-light-gray;
+    box-sizing: border-box;
+    font-size: 14px;
+    height: 48px;
+    line-height: 48px;
+    margin-top: 16px;
+    text-align: center;
+  }
+
+  &__total-price-label {
     font-size: 18px;
+    font-weight: 600;
     padding: 16px 0;
     text-align: left;
-    font-weight: 600;
   }
-  &__buy-price {
-    font-size: 28px;
-    float: right;
-    position: relative;
+
+  &__total-price {
     bottom: 3px;
+    float: right;
+    font-size: 28px;
+    position: relative;
   }
+
   &__error-message {
     text-align: center;
     margin: 8px 0 0;
-    color: #ea352d;
+    color: $color-red;
     font-size: 14px;
   }
-  &__purchase-btn {
-    display: block;
-    width: 100%;
-    line-height: 48px;
-    font-size: 14px;
-    background: #ea352d;
-    color: #fff;
-    font-weight: 600;
-    text-align: center;
-    margin-top: 8px;
+}
+
+.confirm-purchase-btn {
+  background: $color-red;
+  color: $color-white;
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 48px;
+  margin-top: 8px;
+  text-align: center;
+  width: 100%;
+}
+
+.btn-disabled {
+  background: #888;
+  border: 1px solid #888;
+  color: #fff;
+  cursor: not-allowed;
+}
+
+.confirm-user {
+  border-top: 1px solid $color-bg-gray;
+  font-size: 14px;
+  margin: 40px 0 0;
+  padding: 24px 12.5% 0;
+
+  &--btm {
+    padding-bottom: 40px;
   }
-  &__user-info {
-    margin: 40px 0 0;
-    padding: 24px 12.5% 0;
-    border-top: 1px solid #f5f5f5;
-    font-size: 14px;
-    &--bottom {
-      padding-bottom: 40px;
-    }
-    &__address {
-      margin-top: 8px;
-      &--head {
-        font-weight: bold;
-      }
-    }
-    &__payment {
-      margin-top: 8px;
-      &--head {
-        font-weight: bold;
-      }
-      &__img {
-        height: 15px;
-      }
-    }
-    &__link {
-      text-align: right;
-    }
-    &__change {
-      color: #0099e8;
-      &:hover {
-        opacity: 0.7;
-        text-decoration: underline;
-      }
-    }
+}
+
+.confirm-address {
+  margin: 8px 0 0 0;
+
+  &__head {
+    font-weight: bold;
+  }
+}
+
+.confirm-link {
+  text-align: right;
+
+    &:hover {
+    opacity: 0.7;
+    text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/_products_detail.scss
+++ b/app/assets/stylesheets/_products_detail.scss
@@ -1,3 +1,6 @@
+$color-gray: #888;
+$white: #fff;
+
 .visible-sp {
   display: none;
 }
@@ -147,4 +150,40 @@ nav ol, nav ul {
     position: relative;
     width: auto;
   }
+}
+
+.tag-sold-show {
+  border-top: 80px solid transparent;
+  border-right: 80px solid transparent;
+  border-bottom: 80px solid $color-red;
+  border-left: 80px solid transparent;
+  bottom: 380px;
+  box-sizing: border-box;
+  height: 80px;
+  margin-bottom: -130px;
+  position: relative;
+  right: 80px;
+  width: 80px;
+  transform: rotate(-45deg);
+
+  &__text {
+    color: $color-white;
+    font-size: 26px;
+    position: relative;
+    right: 35px;
+    top: 45px;
+    z-index: 10;
+  }
+}
+
+.product-btn-sold {
+  background-color: $color-gray;
+  color: $white;
+  cursor: not-allowed;
+  font-size: 24px;
+  font-weight: 600;
+  height: 56px;
+  line-height: 56px;
+  margin: 16px 0;
+  text-align: center;
 }

--- a/app/assets/stylesheets/_products_detail.scss
+++ b/app/assets/stylesheets/_products_detail.scss
@@ -153,10 +153,10 @@ nav ol, nav ul {
 }
 
 .tag-sold-show {
-  border-top: 80px solid transparent;
-  border-right: 80px solid transparent;
   border-bottom: 80px solid $color-red;
   border-left: 80px solid transparent;
+  border-right: 80px solid transparent;
+  border-top: 80px solid transparent;
   bottom: 380px;
   box-sizing: border-box;
   height: 80px;
@@ -186,4 +186,12 @@ nav ol, nav ul {
   line-height: 56px;
   margin: 16px 0;
   text-align: center;
+}
+
+.product-heart-icon {
+  color: #f28fb1;
+}
+
+.product-flag-icon {
+  color: #be4dda;
 }

--- a/app/assets/stylesheets/_products_detail.scss
+++ b/app/assets/stylesheets/_products_detail.scss
@@ -1,4 +1,6 @@
 $color-gray: #888;
+$color-pink: #f28fb1;
+$color-purple: #be4dda;
 $white: #fff;
 
 .visible-sp {
@@ -163,8 +165,8 @@ nav ol, nav ul {
   margin-bottom: -130px;
   position: relative;
   right: 80px;
-  width: 80px;
   transform: rotate(-45deg);
+  width: 80px;
 
   &__text {
     color: $color-white;
@@ -189,9 +191,9 @@ nav ol, nav ul {
 }
 
 .product-heart-icon {
-  color: #f28fb1;
+  color: $color-pink;
 }
 
 .product-flag-icon {
-  color: #be4dda;
+  color: $color-purple;
 }

--- a/app/assets/stylesheets/categories/_categories.scss
+++ b/app/assets/stylesheets/categories/_categories.scss
@@ -143,8 +143,8 @@ $red: #ea362e;
   margin-bottom: -130px;
   position: relative;
   right: 65px;
-  width: 65px;
   transform: rotate(-45deg);
+  width: 65px;
 
   &__text {
     color: $color-white;

--- a/app/assets/stylesheets/categories/_categories.scss
+++ b/app/assets/stylesheets/categories/_categories.scss
@@ -133,10 +133,10 @@ $red: #ea362e;
 }
 
 .tag-sold-category {
-  border-top: 65px solid transparent;
-  border-right: 65px solid transparent;
   border-bottom: 65px solid $color-red;
   border-left: 65px solid transparent;
+  border-right: 65px solid transparent;
+  border-top: 65px solid transparent;
   bottom: 255px;
   box-sizing: border-box;
   height: 65px;

--- a/app/assets/stylesheets/categories/_categories.scss
+++ b/app/assets/stylesheets/categories/_categories.scss
@@ -131,3 +131,27 @@ $red: #ea362e;
     line-height: 44px;
   }
 }
+
+.tag-sold-category {
+  border-top: 65px solid transparent;
+  border-right: 65px solid transparent;
+  border-bottom: 65px solid $color-red;
+  border-left: 65px solid transparent;
+  bottom: 255px;
+  box-sizing: border-box;
+  height: 65px;
+  margin-bottom: -130px;
+  position: relative;
+  right: 65px;
+  width: 65px;
+  transform: rotate(-45deg);
+
+  &__text {
+    color: $color-white;
+    font-size: 23px;
+    position: relative;
+    right: 32px;
+    top: 35px;
+    z-index: 10;
+  }
+}

--- a/app/assets/stylesheets/signup/_users_signup.scss
+++ b/app/assets/stylesheets/signup/_users_signup.scss
@@ -9,15 +9,17 @@ $color-bg-gray: #f5f5f5;
 }
 .signup {
   &__header {
+    align-items: center;
     background-color: $color-bg-gray;
     display: flex;
-    width: 100vw;
     height: 128px;
     justify-content: center;
-    align-items: center;
+    width: 100vw;
+
     &__logo {
       width: 230px;
     }
+
     &__logo:hover {
       opacity: 0.7;
     }

--- a/app/assets/stylesheets/signup/_users_signup.scss
+++ b/app/assets/stylesheets/signup/_users_signup.scss
@@ -1,13 +1,15 @@
 $color-white: #fff;
+$color-bg-gray: #f5f5f5;
 
 .signup-container {
   color: #333;
-  background-color: #f5f5f5;
+  background-color: $color-bg-gray;
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic",
     "メイリオ", "Meiryo", sans-serif;
 }
 .signup {
   &__header {
+    background-color: $color-bg-gray;
     display: flex;
     width: 100vw;
     height: 128px;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -57,6 +57,7 @@ class ProductsController < ApplicationController
     )
 
     if charge["captured"]
+      @product.update(order_status: true, buyer_id: current_user.id)
       redirect_to root_path
     else
       render :confirm

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,9 +1,10 @@
 class ProductsController < ApplicationController
   require 'payjp'
 
-  before_action :set_product, only: [:show, :edit, :update, :destroy, :purchase, :confirm]
+  before_action :set_product, only: [:show, :edit, :update, :destroy, :purchase, :confirm, :complete]
   before_action :set_category_menu, only: [:index, :show, :search]
   before_action :set_Category, only: [:new, :create, :edit, :update]
+  before_action :set_card, only: [:confirm, :complete]
 
 
   def index
@@ -35,20 +36,11 @@ class ProductsController < ApplicationController
   end
 
   def confirm
-    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
-    @address = current_user.address
-    @cards = Array.new
-    users_cards = current_user.cards
-    users_cards.each do |card|
-      customer = Payjp::Customer.retrieve(card.customer)
-      @cards << customer.cards.retrieve(card.card)
-    end
   end
 
   def purchase
     cards = current_user.cards
     card = cards[0]
-
     Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     charge = Payjp::Charge.create(
       amount: @product.price,
@@ -58,10 +50,13 @@ class ProductsController < ApplicationController
 
     if charge["captured"]
       @product.update(order_status: true, buyer_id: current_user.id)
-      redirect_to root_path
+      redirect_to complete_product_path(@product)
     else
       render :confirm
     end
+  end
+
+  def complete
   end
 
   def search
@@ -84,8 +79,21 @@ class ProductsController < ApplicationController
   
   private
   def product_params
-    params.require(:product).permit(:product_name, :description, :first_category_id, :second_category_id, :third_category_id, :condition, :delivery_charge, :delivery_way, :delivery_date,:price,
-      :order_status, :prefecture_id, images_attributes: [ :image, :_destroy, :id ])   
+    params.require(:product).permit(
+      :product_name,
+      :description,
+      :first_category_id,
+      :second_category_id,
+      :third_category_id,
+      :condition,
+      :delivery_charge,
+      :delivery_way,
+      :delivery_date,
+      :price,
+      :order_status,
+      :prefecture_id,
+      images_attributes: [ :image, :_destroy, :id ]
+      )   
   end
   
   def set_Category
@@ -95,5 +103,14 @@ class ProductsController < ApplicationController
 
   def set_product
     @product = Product.find(params[:id])
+  end
+
+  def set_card
+    @cards = Array.new
+    users_cards = current_user.cards
+    users_cards.each do |card|
+      customer = Payjp::Customer.retrieve(card.customer)
+      @cards << customer.cards.retrieve(card.card)
+    end
   end
 end

--- a/app/views/categories/_product.html.haml
+++ b/app/views/categories/_product.html.haml
@@ -3,13 +3,16 @@
   .item-box__photo
     = image_tag product.images.first.image,
       class: 'item-box__photo-img'
+  - if product.order_status == true
+    .tag-sold-category
+      %span.tag-sold-category__text SOLD
   .item-box__body
     .item-box__name
       = product.product_name
     .item-box__info
       .item-box__price
         %span<>¥
-        = product.price
+        = product.price.to_s(:delimited)
       .item-box__likes
         %i.far.fa-heart
         %span 0

--- a/app/views/products/_product.html.haml
+++ b/app/views/products/_product.html.haml
@@ -3,13 +3,16 @@
   .top-items__photo
     = image_tag product.images.first.image,
       class: 'top-items__photo-img'
+  - if product.order_status == true
+    .tag-sold.tag-sold__bg
+      %span.tag-sold__text SOLD
   .top-items__body
     .top-items__name
       = product.product_name
     .top-items__info
       .top-items__price
         %span<>¥
-        = product.price
+        = product.price.to_s(:delimited)
       .top-items__likes
         %i.far.fa-heart
         %span 0

--- a/app/views/products/_product.html.haml
+++ b/app/views/products/_product.html.haml
@@ -4,7 +4,7 @@
     = image_tag product.images.first.image,
       class: 'top-items__photo-img'
   - if product.order_status == true
-    .tag-sold.tag-sold__bg
+    .tag-sold
       %span.tag-sold__text SOLD
   .top-items__body
     .top-items__name

--- a/app/views/products/complete.html.haml
+++ b/app/views/products/complete.html.haml
@@ -48,18 +48,15 @@
             %br
             = render "cards/cards",
               brand: @cards[0]["brand"]
-          .confirm-link
-            = link_to("変更する＞",
-              root_path)
       .complete-text-center
         .complete-text-bold
           発送通知後の流れ
           .complete-icons
             %i.far.fa-star.fa-xs
             %i.far.fa-star.fa-sm
-            %i.fas.fa-smile-wink{style: "color: #ef5185"}
-            %i.fas.fa-meh{style: "color: #fbaa34"}
-            %i.fas.fa-frown-open{style: "color: #69b5d8"}
+            %i.fas.fa-smile-wink.complete-icons-wink
+            %i.fas.fa-meh.complete-icons-meh
+            %i.fas.fa-frown-open.complete-icons-frown
             %i.far.fa-star.fa-sm
             %i.far.fa-star.fa-xs
         .complete-text

--- a/app/views/products/complete.html.haml
+++ b/app/views/products/complete.html.haml
@@ -1,0 +1,74 @@
+= render partial: "users/signup-header"
+.confirm-main
+  .confirm-main__container
+    .complete-alert
+      .complete-alert-head
+        %i.far.fa-clock.fa-2x
+        %span 発送をお待ちください
+      .complete-alert-text
+        出品者からの発送通知をお待ちください
+    %h2.complete-head
+      購入内容の確認
+    .confirm-content
+      .complete-item
+        = image_tag @product.images.first.image,
+          class: 'complete-item__image'
+        .complete-item__text
+          = @product.product_name
+      .complete-text-center
+        %span.complete-price-text<>
+          ¥
+          = @product.price.to_s(:delimited, delimiter: ',')
+        %span.confirm-item__shipment-fee
+          = @product.delivery_charge
+      .complete-text-left
+        %h3.confirm-address__head
+          配送先
+        .confirm-address
+          %span<>〒
+          = current_user.address.postal_code
+          %br
+          = user_address(current_user.address)
+          %br
+          = user_name(current_user.address)
+      .complete-text-left
+        %h3.confirm-address__head
+          支払い方法
+        .confirm-address
+          - if @cards.blank?
+            %span /
+          - else
+            ************
+            %span<>
+            = @cards[0]["last4"]
+            %br
+            = sprintf("%02d", @cards[0]["exp_month"])
+            %span /
+            = @cards[0]["exp_year"] % 100
+            %br
+            = render "cards/cards",
+              brand: @cards[0]["brand"]
+          .confirm-link
+            = link_to("変更する＞",
+              root_path)
+      .complete-text-center
+        .complete-text-bold
+          発送通知後の流れ
+          .complete-icons
+            %i.far.fa-star.fa-xs
+            %i.far.fa-star.fa-sm
+            %i.fas.fa-smile-wink{style: "color: #ef5185"}
+            %i.fas.fa-meh{style: "color: #fbaa34"}
+            %i.fas.fa-frown-open{style: "color: #69b5d8"}
+            %i.far.fa-star.fa-sm
+            %i.far.fa-star.fa-xs
+        .complete-text
+          商品を受け取ったら出品者の評価をしましょう。
+          %br
+          購入代金が出品者に振り込まれます。
+          %br
+          評価後に取引は完了です。
+        = link_to("マイページへ戻る",
+          users_mypage_path,
+          class: "complete-link-text")
+= render partial: "users/signup-footer"

--- a/app/views/products/confirm.html.haml
+++ b/app/views/products/confirm.html.haml
@@ -1,75 +1,72 @@
-.products-confirm
-  %header.products-confirm__header
-    = link_to root_path do
-      = image_tag 'mercari_logo_horizontal.png',
-        class: 'products-confirm__header__logo'
-  %main.products-confirm__main
-    .products-confirm__main__container
-      %h2.products-confirm__main__head
-        購入内容の確認
-      .products-confirm__main__item
-        .products-confirm__main--inner
-          = image_tag 'products_confirm_img.jpg',
-            class: 'products-confirm__image'
-          %p.products-confirm__product-name
-            - if @product.product_name.length > 39
-              = @product.product_name.slice(0..38)
-              %span<>…
-            - else
-              = @product.product_name
-          %p.products-confirm__product-price
-            %span<>¥
+.confirm-header
+  = render partial: "users/signup-header"
+.confirm-main
+  .confirm-main__container
+    %h2.confirm-head
+      購入内容の確認
+    .confirm-content
+      .confirm-item
+        = image_tag @product.images.first.image,
+          class: 'confirm-item__image'
+        %p.confirm-item__name
+          - if @product.product_name.length > 39
+            = @product.product_name.slice(0..38)
+            %span<>…
+          - else
+            = @product.product_name
+        %p.confirm-item__price
+          %span<>¥
+          = @product.price.to_s(:delimited, delimiter: ',')
+          %span.confirm-item__shipment-fee
+            = @product.delivery_charge
+        .confirm-item__point
+          ポイントはありません
+        .confirm-item__total-price-label
+          支払い金額
+          %span.confirm-item__total-price<>
+            ¥
             = @product.price.to_s(:delimited, delimiter: ',')
-            %span.products-confirm__product-price--shipment-fee
-              = @product.delivery_charge
-          .products-confirm__users-point--none
-            ポイントはありません
-          .products-confirm__buy-price-label
-            支払い金額
-            %span.products-confirm__buy-price 
-              = @product.price.to_s(:delimited, delimiter: ',')
-          - if @address.blank? || @cards.blank?
-            .products-confirm__error-message
-              配送先と支払い方法の入力を完了してください。
+        - if @address.blank? || @cards.blank?
+          .confirm-item__error-message
+            配送先と支払い方法の入力を完了してください。
+          .confirm-purchase-btn.btn-disabled
+            購入する
+        - else
           = link_to("購入する",
             purchase_product_path,
             method: :post,
-            class: "products-confirm__purchase-btn")
-        .products-confirm__user-info
-          .products-confirm__main--inner
-            %h3.products-confirm__user-info__address--head
-              配送先
-            .products-confirm__user-info__address
-              %span<>〒
-              = @address.postal_code
-              %br
-              = user_address(@address)
-              %br
-              = user_name(@address)
-            .products-confirm__user-info__link
-              = link_to("変更する＞",
-                root_path,
-                class: "products-confirm__user-info__change")
-        .products-confirm__user-info.products-confirm__user-info--bottom
-          .products-confirm__main--inner
-            %h3.products-confirm__user-info__payment--head
-              支払い方法
-            .products-confirm__user-info__payment
-              - if @cards.blank?
-                %span /
-              - else
-                ************
-                %span<>
-                = @cards[0]["last4"]
-                %br
-                = sprintf("%02d", @cards[0]["exp_month"])
-                %span /
-                = @cards[0]["exp_year"] % 100
-                %br
-                = render "cards/cards",
-                  brand: @cards[0]["brand"]
-              .products-confirm__user-info__link
-                = link_to("変更する＞",
-                  root_path,
-                  class: "products-confirm__user-info__change")
-  = render partial: "users/signup-footer"
+            class: "confirm-purchase-btn")
+      .confirm-user
+        %h3.confirm-address__head
+          配送先
+        .confirm-address
+          %span<>〒
+          = @address.postal_code
+          %br
+          = user_address(@address)
+          %br
+          = user_name(@address)
+        .confirm-link
+          = link_to("変更する＞",
+            root_path)
+      .confirm-user.confirm-user--btm
+        %h3.confirm-address__head
+          支払い方法
+        .confirm-address
+          - if @cards.blank?
+            %span /
+          - else
+            ************
+            %span<>
+            = @cards[0]["last4"]
+            %br
+            = sprintf("%02d", @cards[0]["exp_month"])
+            %span /
+            = @cards[0]["exp_year"] % 100
+            %br
+            = render "cards/cards",
+              brand: @cards[0]["brand"]
+          .confirm-link
+            = link_to("変更する＞",
+              root_path)
+= render partial: "users/signup-footer"

--- a/app/views/products/confirm.html.haml
+++ b/app/views/products/confirm.html.haml
@@ -1,5 +1,4 @@
-.confirm-header
-  = render partial: "users/signup-header"
+= render partial: "users/signup-header"
 .confirm-main
   .confirm-main__container
     %h2.confirm-head
@@ -26,7 +25,7 @@
           %span.confirm-item__total-price<>
             ¥
             = @product.price.to_s(:delimited, delimiter: ',')
-        - if @address.blank? || @cards.blank?
+        - if current_user.address.blank? || @cards.blank?
           .confirm-item__error-message
             配送先と支払い方法の入力を完了してください。
           .confirm-purchase-btn.btn-disabled
@@ -41,11 +40,11 @@
           配送先
         .confirm-address
           %span<>〒
-          = @address.postal_code
+          = current_user.address.postal_code
           %br
-          = user_address(@address)
+          = user_address(current_user.address)
           %br
-          = user_name(@address)
+          = user_name(current_user.address)
         .confirm-link
           = link_to("変更する＞",
             root_path)

--- a/app/views/products/search.html.haml
+++ b/app/views/products/search.html.haml
@@ -20,7 +20,12 @@
           %section.search-box.search-id
             = link_to product_path(pro) do
               %figure.search-box-photo
-                = image_tag "#{pro.images.first.image}",width: "160" ,hight: "160"
+                = image_tag "#{pro.images.first.image}",
+                  width: "160",
+                  height: "160"
+                - if pro.order_status == true
+                  .tag-sold.tag-sold--search
+                    %span.tag-sold__text SOLD
               .search-box-body
                 %h3.search-box-name.font-2
                   = pro.product_name

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -12,6 +12,10 @@
                 .eagle-product-inner.is-higher-height
                   = image_tag "#{@product.images.first.image}",
                     class: 'eagle-lazy'
+                  - if @product.order_status == true
+                    .tag-sold-show
+                      %span.tag-sold-show__text SOLD
+                  
           .eagle-dots
             - @product.images.each do |thumbnail|
               .eagle-dot
@@ -80,8 +84,10 @@
         (税込)
       %span.product-shipping-fee
         送料込み
-      
-      - if user_signed_in?
+      - if @product.order_status == true
+        .product-btn-sold
+          売り切れました
+      - elsif user_signed_in?
         - unless current_user.id == @product.user_id
           = link_to "購入画面に進む",
             confirm_product_path(@product),

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -144,13 +144,13 @@
     %ul.social-media-box
       %li
         %a
-          = image_tag "fb_b.png",width: "44" ,hight: "44"
+          = image_tag "fb_b.png", width: "44"
       %li
         %a
-          = image_tag "tw_b.png",width: "44" ,hight: "44"
+          = image_tag "tw_b.png", width: "44"
       %li
         %a
-          = image_tag "pin_r.jpg",width: "44" ,hight: "44"
+          = image_tag "pin_r.jpg", width: "44"
   .products-in-user-profile
     %section.products-box-container.clearfix.related-product-column.products-in-user-profile
       %h2.products-box-head

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,5 +1,5 @@
 .default-container 
-  = render  'shared/header'
+  = render 'shared/header'
   %section.product-box-container.large-single-container
     %h1.product-name
       = @product.product_name
@@ -7,21 +7,23 @@
       .product-photo
         .eagle-carousel.eagle-loaded.eagle-drag
           .eagle-stage-outer
-            .eagle-stage{ "style":"left: 0px width: 900px" }
-              .eagle-product.active{ "style":"width: 300px" }
+            .eagle-stage
+              .eagle-product.active
                 .eagle-product-inner.is-higher-height
-                  = image_tag "#{@product.images.first[:image]}", class: 'eagle-lazy',width: "300" ,hight: "300"
+                  = image_tag "#{@product.images.first.image}",
+                    class: 'eagle-lazy'
           .eagle-dots
             - @product.images.each do |thumbnail|
               .eagle-dot
                 .eagle-dot-inner
-                  = image_tag "#{thumbnail.image}", class: 'eagle-lazy',width: "60" ,hight: "60"
+                  = image_tag "#{thumbnail.image}",
+                    class: 'eagle-lazy'
       %table.product-detail-table
         %tbody
           %tr
             %th 出品者
             %td
-              = link_to "#{@product.user.nickname}","/"
+              = link_to "#{@product.user.nickname}", root_path
               %div
                 .product-user-ratings
                   %i.icon-good.icon-size
@@ -39,15 +41,18 @@
             %th カテゴリー
             %td
               %div
-              = link_to @product.first_category.first_category, root_path
+              = link_to @product.first_category.first_category,
+                root_path
               %div
-              = link_to @product.second_category.second_category, root_path
+              = link_to "＞#{@product.second_category.second_category}",
+                root_path
               %div
-              = link_to @product.third_category.third_category, root_path
+              = link_to "＞#{@product.third_category.third_category}",
+                root_path
           %tr
             %th ブランド
             %td 
-              = link_to "未実装","/"
+              = link_to "未実装", root_path
           %tr
             %th 商品の状態
             %td 
@@ -75,31 +80,31 @@
         (税込)
       %span.product-shipping-fee
         送料込み
+      
       - if user_signed_in?
         - unless current_user.id == @product.user_id
-          = link_to "購入画面に進む",  destroy_user_session_path,class: "product-buy-btn", method: :delete
+          = link_to "購入画面に進む",
+            confirm_product_path(@product),
+            class: "product-buy-btn"
       - else 
-        = link_to "購入画面に進む",  destroy_user_session_path,class: "product-buy-btn", method: :delete
-    -# %a.product-btn-client
-    -#   %div{"data-client": "#{'visible'}"}
-    -#     購入画面に進む
-    -#     =link_to "購入画面に進む", myprofile_path(@product.id)
-      -# .product-action-text{"data-toggle": "#{'open-app'}","data-url-scheme": "#{'mercari://'}","data-action": "#{'product/openDetail'}",'data-key': "#{'id=aaaaaaaa'}","data-paly-id": "#{"com.kouzoh.mercari"}","data-adjust-url": "http://app.adjust.io/xio2ii?campaign=iOS&adgroup=items.buy_button1aaaaaa"}
-      -#   アプリで購入　　←※スマホ用
+        = link_to "購入画面に進む",
+          users_login_path,
+          class: "product-buy-btn"
     .product-description.f14
-      = simple_format "#{@product.description}", class:'product-description-inner'
+      = simple_format "#{@product.description}",
+        class:'product-description-inner'
     .product-button-container.clearfix
       .product-button-left
-        %button.product-button.product-button-like{"name": "like!","data-toggle": "like","data-id": "#{"xxxxxxxx"}","data-ga":"#{"element"}","dara-ga-category": "#{'LIKE'}"}
+        %button.product-button.product-button-like
           %i.icon-like-border
-            = image_tag "sample_heart.png",width: "15" ,hight: "15"
+            %i.far.fa-heart{ style: "color: #F28FB1" }
             %span
               良いね！
-            %span.fade-in-down{"data-num":"#{"like"}"}
+            %span.fade-in-down
               0
-        %button.product-button.product-button-report.clearfix{"data-modal":"#{"report-product"}","data-open":"#{"modal"}"}
+        %button.product-button.product-button-report.clearfix
           %i.icon-flag
-            = image_tag "sample_flag.png",width: "15" ,hight: "15"
+            %i.far.fa-flag{ style: "color: #BE4DDA" }
             %span
               不適切な商品の報告
       .product-button-right
@@ -185,4 +190,4 @@
                     %span
                     = "#{"1"}"
   = render 'shared/bread-crumbs'
-  = render  'shared/footer'
+  = render 'shared/footer'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -15,7 +15,6 @@
                   - if @product.order_status == true
                     .tag-sold-show
                       %span.tag-sold-show__text SOLD
-                  
           .eagle-dots
             - @product.images.each do |thumbnail|
               .eagle-dot
@@ -103,14 +102,14 @@
       .product-button-left
         %button.product-button.product-button-like
           %i.icon-like-border
-            %i.far.fa-heart{ style: "color: #F28FB1" }
+            %i.far.fa-heart.product-heart-icon
             %span
               良いね！
             %span.fade-in-down
               0
         %button.product-button.product-button-report.clearfix
           %i.icon-flag
-            %i.far.fa-flag{ style: "color: #BE4DDA" }
+            %i.far.fa-flag.product-flag-icon
             %span
               不適切な商品の報告
       .product-button-right

--- a/app/views/users/_signup-footer.html.haml
+++ b/app/views/users/_signup-footer.html.haml
@@ -7,7 +7,7 @@
         %a{href: "/", class: "signup__footer__nav__link"} メルカリ利用規約
       %li
         %a{href: "/", class: "signup__footer__nav__link"} 特定商取引に関する表記
-    %a(href="/")
+    = link_to root_path do
       = image_tag 'mercari_logo_vertical', class: 'signup__footer__nav__logo'
     %p.signup__footer__nav__text
       © 2019 Mercari

--- a/app/views/users/_signup-header.html.haml
+++ b/app/views/users/_signup-header.html.haml
@@ -1,4 +1,6 @@
 %header.signup__header
   %h1
-    %a(href="/")
-      = image_tag 'mercari_logo_horizontal', class: 'signup__header__logo'
+    = link_to root_path do
+      = image_tag 'mercari_logo_horizontal.png',
+        class: 'products-confirm__header__logo',
+        style: "width: 230px";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     member do
       get 'confirm'
       post 'purchase'
+      get 'complete'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
   match 'secondcategory', to: 'products#secondcategory', via: [:get, :post]
   match 'thirdcategory', to: 'products#thirdcategory', via: [:get, :post]
   get '/products/search', to: 'products#search'
-  get "/products/confirm", to: "products#confirm"
   get "/products/sell", to: "products#sell"
 
   resources :products, only: [:index, :show, :create] do

--- a/db/migrate/20190821104838_change_column_of_products.rb
+++ b/db/migrate/20190821104838_change_column_of_products.rb
@@ -1,0 +1,6 @@
+class ChangeColumnOfProducts < ActiveRecord::Migration[5.0]
+  def change
+    change_column :products, :order_status, :boolean
+    add_column :products, :buyer_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190821050433) do
+ActiveRecord::Schema.define(version: 20190821104838) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string  "postal_code",      null: false
@@ -76,13 +76,14 @@ ActiveRecord::Schema.define(version: 20190821050433) do
     t.string  "delivery_charge",                  null: false
     t.string  "delivery_date",                    null: false
     t.string  "delivery_way",                     null: false
-    t.string  "order_status"
+    t.boolean "order_status"
     t.integer "first_category_id"
     t.integer "second_category_id"
     t.integer "third_category_id"
     t.integer "brand_id"
     t.integer "size_id"
     t.integer "prefecture_id",                    null: false
+    t.integer "buyer_id"
     t.index ["brand_id"], name: "index_products_on_brand_id", using: :btree
     t.index ["first_category_id"], name: "index_products_on_first_category_id", using: :btree
     t.index ["second_category_id"], name: "index_products_on_second_category_id", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1915 +1,1925 @@
-FirstCategory.create!(
-  [
-    {
-      first_category: 'レディース',
-    },
-    {
-      first_category: 'メンズ',
-    },
-    {
-      first_category: 'ベビー・キッズ',
-    },
-    {
-      first_category: 'インテリア・住まい・小物',
-    },
-    {
-      first_category: '本・音楽・ゲーム',
-    },
-    {
-      first_category: 'おもちゃ・ホビー・グッズ',
-    },
-    {
-      first_category: 'コスメ・香水・美容',
-    },
-    {
-      first_category: '家電・スマホ・カメラ',
-    },
-    {
-      first_category: 'スポーツ・レジャー',
-    },
-    {
-      first_category: 'ハンドメイド',
-    },
-    {
-      first_category: 'チケット',
-    },
-    {
-      first_category: '自動車・オートバイ',
-    },
-    {
-      first_category: 'その他',
-    }
-  ]
-)
+# FirstCategory.create!(
+#   [
+#     {
+#       first_category: 'レディース',
+#     },
+#     {
+#       first_category: 'メンズ',
+#     },
+#     {
+#       first_category: 'ベビー・キッズ',
+#     },
+#     {
+#       first_category: 'インテリア・住まい・小物',
+#     },
+#     {
+#       first_category: '本・音楽・ゲーム',
+#     },
+#     {
+#       first_category: 'おもちゃ・ホビー・グッズ',
+#     },
+#     {
+#       first_category: 'コスメ・香水・美容',
+#     },
+#     {
+#       first_category: '家電・スマホ・カメラ',
+#     },
+#     {
+#       first_category: 'スポーツ・レジャー',
+#     },
+#     {
+#       first_category: 'ハンドメイド',
+#     },
+#     {
+#       first_category: 'チケット',
+#     },
+#     {
+#       first_category: '自動車・オートバイ',
+#     },
+#     {
+#       first_category: 'その他',
+#     }
+#   ]
+# )
 
-SecondCategory.create!(
-  [
-    {
-      first_category_id: '1',
-      second_category: 'トップス',
-    },
-    {
-      first_category_id: '1',
-      second_category: 'ジャケット/アウター',
-    },
-    {
-      first_category_id: '1',
-      second_category: 'パンツ',
-    },
-    {
-      first_category_id: '1',
-      second_category: 'スカート',
-    },
-    {
-      first_category_id: '1',
-      second_category: 'ワンピース',
-    },
-    {
-      first_category_id: '1',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '2',
-      second_category: 'トップス',
-    },
-    {
-      first_category_id: '2',
-      second_category: 'ジャケット/アウター',
-    },
-    {
-      first_category_id: '2',
-      second_category: 'パンツ',
-    },
-    {
-      first_category_id: '2',
-      second_category: '靴',
-    },
-    {
-      first_category_id: '2',
-      second_category: 'バッグ',
-    },
-    {
-      first_category_id: '2',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '3',
-      second_category: 'ベビー服(女の子用)~95cm',
-    },
-    {
-      first_category_id: '3',
-      second_category: 'ベビー服(男の子用)~95cm',
-    },
-    {
-      first_category_id: '3',
-      second_category: 'ベビー服(男女兼用)~95cm',
-    },
-    {
-      first_category_id: '3',
-      second_category: 'キッズ服(女の子用)100cm~',
-    },
-    {
-      first_category_id: '3',
-      second_category: 'キッズ服(男の子用)100cm〜',
-    },
-    {
-      first_category_id: '3',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '4',
-      second_category: 'キッチン/食器',
-    },
-    {
-      first_category_id: '4',
-      second_category: 'ベッド/マットレス',
-    },
-    {
-      first_category_id: '4',
-      second_category: 'ソファ/ソファベッド',
-    },
-    {
-      first_category_id: '4',
-      second_category: '椅子/チェア',
-    },
-    {
-      first_category_id: '4',
-      second_category: '机/テーブル',
-    },
-    {
-      first_category_id: '4',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '5',
-      second_category: '本',
-    },
-    {
-      first_category_id: '5',
-      second_category: '漫画',
-    },
-    {
-      first_category_id: '5',
-      second_category: '雑誌',
-    },
-    {
-      first_category_id: '5',
-      second_category: 'CD',
-    },
-    {
-      first_category_id: '5',
-      second_category: 'DVD/ブルーレイ',
-    },
-    {
-      first_category_id: '5',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '6',
-      second_category: 'おもちゃ',
-    },
-    {
-      first_category_id: '6',
-      second_category: 'タレントグッズ',
-    },
-    {
-      first_category_id: '6',
-      second_category: 'コミック/アニメグッズ',
-    },
-    {
-      first_category_id: '6',
-      second_category: 'トレーディングカード',
-    },
-    {
-      first_category_id: '6',
-      second_category: 'フィギュア',
-    },
-    {
-      first_category_id: '6',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '7',
-      second_category: 'ベースメイク',
-    },
-    {
-      first_category_id: '7',
-      second_category: 'メイクアップ',
-    },
-    {
-      first_category_id: '7',
-      second_category: 'ネイルケア',
-    },
-    {
-      first_category_id: '7',
-      second_category: '香水',
-    },
-    {
-      first_category_id: '7',
-      second_category: 'スキンケア/基礎化粧品',
-    },
-    {
-      first_category_id: '7',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '8',
-      second_category: 'スマートフォン/携帯電話',
-    },
-    {
-      first_category_id: '8',
-      second_category: 'スマホアクセサリー',
-    },
-    {
-      first_category_id: '8',
-      second_category: 'PC/タブレット',
-    },
-    {
-      first_category_id: '8',
-      second_category: 'カメラ',
-    },
-    {
-      first_category_id: '8',
-      second_category: 'テレビ/映像機器',
-    },
-    {
-      first_category_id: '8',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '9',
-      second_category: 'ゴルフ',
-    },
-    {
-      first_category_id: '9',
-      second_category: 'フィッシング',
-    },
-    {
-      first_category_id: '9',
-      second_category: '自転車',
-    },
-    {
-      first_category_id: '9',
-      second_category: 'トレーニング/エクササイズ',
-    },
-    {
-      first_category_id: '9',
-      second_category: '野球',
-    },
-    {
-      first_category_id: '9',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '10',
-      second_category: 'アクセサリー(女性用)',
-    },
-    {
-      first_category_id: '10',
-      second_category: 'ファッション/小物',
-    },
-    {
-      first_category_id: '10',
-      second_category: 'アクセサリー/時計',
-    },
-    {
-      first_category_id: '10',
-      second_category: '日用品/インテリア',
-    },
-    {
-      first_category_id: '10',
-      second_category: '趣味/おもちゃ',
-    },
-    {
-      first_category_id: '10',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '11',
-      second_category: '音楽',
-    },
-    {
-      first_category_id: '11',
-      second_category: 'スポーツ',
-    },
-    {
-      first_category_id: '11',
-      second_category: '演劇/芸能',
-    },
-    {
-      first_category_id: '11',
-      second_category: 'イベント',
-    },
-    {
-      first_category_id: '11',
-      second_category: '映画',
-    },
-    {
-      first_category_id: '11',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '12',
-      second_category: '自動車本体',
-    },
-    {
-      first_category_id: '12',
-      second_category: '自動車本体/ホイール',
-    },
-    {
-      first_category_id: '12',
-      second_category: '自動車パーツ',
-    },
-    {
-      first_category_id: '12',
-      second_category: '自動車アクセサリー',
-    },
-    {
-      first_category_id: '12',
-      second_category: 'オートバイ本体',
-    },
-    {
-      first_category_id: '12',
-      second_category: 'その他',
-    },
-    {
-      first_category_id: '13',
-      second_category: 'まとめ売り',
-    },
-    {
-      first_category_id: '13',
-      second_category: 'ペット用品',
-    },
-    {
-      first_category_id: '13',
-      second_category: '食品',
-    },
-    {
-      first_category_id: '13',
-      second_category: '飲料/酒',
-    },
-    {
-      first_category_id: '13',
-      second_category: '日用品/生活雑貨/旅行',
-    },
-    {
-      first_category_id: '13',
-      second_category: 'その他',
-    },
-  ]
-)
+# SecondCategory.create!(
+#   [
+#     {
+#       first_category_id: '1',
+#       second_category: 'トップス',
+#     },
+#     {
+#       first_category_id: '1',
+#       second_category: 'ジャケット/アウター',
+#     },
+#     {
+#       first_category_id: '1',
+#       second_category: 'パンツ',
+#     },
+#     {
+#       first_category_id: '1',
+#       second_category: 'スカート',
+#     },
+#     {
+#       first_category_id: '1',
+#       second_category: 'ワンピース',
+#     },
+#     {
+#       first_category_id: '1',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '2',
+#       second_category: 'トップス',
+#     },
+#     {
+#       first_category_id: '2',
+#       second_category: 'ジャケット/アウター',
+#     },
+#     {
+#       first_category_id: '2',
+#       second_category: 'パンツ',
+#     },
+#     {
+#       first_category_id: '2',
+#       second_category: '靴',
+#     },
+#     {
+#       first_category_id: '2',
+#       second_category: 'バッグ',
+#     },
+#     {
+#       first_category_id: '2',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '3',
+#       second_category: 'ベビー服(女の子用)~95cm',
+#     },
+#     {
+#       first_category_id: '3',
+#       second_category: 'ベビー服(男の子用)~95cm',
+#     },
+#     {
+#       first_category_id: '3',
+#       second_category: 'ベビー服(男女兼用)~95cm',
+#     },
+#     {
+#       first_category_id: '3',
+#       second_category: 'キッズ服(女の子用)100cm~',
+#     },
+#     {
+#       first_category_id: '3',
+#       second_category: 'キッズ服(男の子用)100cm〜',
+#     },
+#     {
+#       first_category_id: '3',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '4',
+#       second_category: 'キッチン/食器',
+#     },
+#     {
+#       first_category_id: '4',
+#       second_category: 'ベッド/マットレス',
+#     },
+#     {
+#       first_category_id: '4',
+#       second_category: 'ソファ/ソファベッド',
+#     },
+#     {
+#       first_category_id: '4',
+#       second_category: '椅子/チェア',
+#     },
+#     {
+#       first_category_id: '4',
+#       second_category: '机/テーブル',
+#     },
+#     {
+#       first_category_id: '4',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '5',
+#       second_category: '本',
+#     },
+#     {
+#       first_category_id: '5',
+#       second_category: '漫画',
+#     },
+#     {
+#       first_category_id: '5',
+#       second_category: '雑誌',
+#     },
+#     {
+#       first_category_id: '5',
+#       second_category: 'CD',
+#     },
+#     {
+#       first_category_id: '5',
+#       second_category: 'DVD/ブルーレイ',
+#     },
+#     {
+#       first_category_id: '5',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '6',
+#       second_category: 'おもちゃ',
+#     },
+#     {
+#       first_category_id: '6',
+#       second_category: 'タレントグッズ',
+#     },
+#     {
+#       first_category_id: '6',
+#       second_category: 'コミック/アニメグッズ',
+#     },
+#     {
+#       first_category_id: '6',
+#       second_category: 'トレーディングカード',
+#     },
+#     {
+#       first_category_id: '6',
+#       second_category: 'フィギュア',
+#     },
+#     {
+#       first_category_id: '6',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '7',
+#       second_category: 'ベースメイク',
+#     },
+#     {
+#       first_category_id: '7',
+#       second_category: 'メイクアップ',
+#     },
+#     {
+#       first_category_id: '7',
+#       second_category: 'ネイルケア',
+#     },
+#     {
+#       first_category_id: '7',
+#       second_category: '香水',
+#     },
+#     {
+#       first_category_id: '7',
+#       second_category: 'スキンケア/基礎化粧品',
+#     },
+#     {
+#       first_category_id: '7',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '8',
+#       second_category: 'スマートフォン/携帯電話',
+#     },
+#     {
+#       first_category_id: '8',
+#       second_category: 'スマホアクセサリー',
+#     },
+#     {
+#       first_category_id: '8',
+#       second_category: 'PC/タブレット',
+#     },
+#     {
+#       first_category_id: '8',
+#       second_category: 'カメラ',
+#     },
+#     {
+#       first_category_id: '8',
+#       second_category: 'テレビ/映像機器',
+#     },
+#     {
+#       first_category_id: '8',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '9',
+#       second_category: 'ゴルフ',
+#     },
+#     {
+#       first_category_id: '9',
+#       second_category: 'フィッシング',
+#     },
+#     {
+#       first_category_id: '9',
+#       second_category: '自転車',
+#     },
+#     {
+#       first_category_id: '9',
+#       second_category: 'トレーニング/エクササイズ',
+#     },
+#     {
+#       first_category_id: '9',
+#       second_category: '野球',
+#     },
+#     {
+#       first_category_id: '9',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '10',
+#       second_category: 'アクセサリー(女性用)',
+#     },
+#     {
+#       first_category_id: '10',
+#       second_category: 'ファッション/小物',
+#     },
+#     {
+#       first_category_id: '10',
+#       second_category: 'アクセサリー/時計',
+#     },
+#     {
+#       first_category_id: '10',
+#       second_category: '日用品/インテリア',
+#     },
+#     {
+#       first_category_id: '10',
+#       second_category: '趣味/おもちゃ',
+#     },
+#     {
+#       first_category_id: '10',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '11',
+#       second_category: '音楽',
+#     },
+#     {
+#       first_category_id: '11',
+#       second_category: 'スポーツ',
+#     },
+#     {
+#       first_category_id: '11',
+#       second_category: '演劇/芸能',
+#     },
+#     {
+#       first_category_id: '11',
+#       second_category: 'イベント',
+#     },
+#     {
+#       first_category_id: '11',
+#       second_category: '映画',
+#     },
+#     {
+#       first_category_id: '11',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '12',
+#       second_category: '自動車本体',
+#     },
+#     {
+#       first_category_id: '12',
+#       second_category: '自動車本体/ホイール',
+#     },
+#     {
+#       first_category_id: '12',
+#       second_category: '自動車パーツ',
+#     },
+#     {
+#       first_category_id: '12',
+#       second_category: '自動車アクセサリー',
+#     },
+#     {
+#       first_category_id: '12',
+#       second_category: 'オートバイ本体',
+#     },
+#     {
+#       first_category_id: '12',
+#       second_category: 'その他',
+#     },
+#     {
+#       first_category_id: '13',
+#       second_category: 'まとめ売り',
+#     },
+#     {
+#       first_category_id: '13',
+#       second_category: 'ペット用品',
+#     },
+#     {
+#       first_category_id: '13',
+#       second_category: '食品',
+#     },
+#     {
+#       first_category_id: '13',
+#       second_category: '飲料/酒',
+#     },
+#     {
+#       first_category_id: '13',
+#       second_category: '日用品/生活雑貨/旅行',
+#     },
+#     {
+#       first_category_id: '13',
+#       second_category: 'その他',
+#     },
+#   ]
+# )
 
-ThirdCategory.create!(
-  [
-    {
-      second_category_id: '1',
-      third_category: 'Tシャツ/カットソー(半袖/袖なし)',
-    },
-    {
-      second_category_id: '1',
-      third_category: 'Tシャツ/カットソー(七分/長袖)',
-    },
-    {
-      second_category_id: '1',
-      third_category: 'シャツ/ブラウス(半袖/袖なし)',
-    },
-    {
-      second_category_id: '1',
-      third_category: 'シャツ/ブラウス(七分/長袖)',
-    },
-    {
-      second_category_id: '1',
-      third_category: 'ポロシャツ',
-    },
-    {
-      second_category_id: '1',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '2',
-      third_category: 'テーラードジャケット',
-    },
-    {
-      second_category_id: '2',
-      third_category: 'ノーカラージャケット',
-    },
-    {
-      second_category_id: '2',
-      third_category: 'Gジャン/デニムジャケット',
-    },
-    {
-      second_category_id: '2',
-      third_category: 'レザージャケット',
-    },
-    {
-      second_category_id: '2',
-      third_category: 'ダウンジャケット',
-    },
-    {
-      second_category_id: '2',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '3',
-      third_category: 'デニム/ジーンズ',
-    },
-    {
-      second_category_id: '3',
-      third_category: 'ショートパンツ',
-    },
-    {
-      second_category_id: '3',
-      third_category: 'カジュアルパンツ',
-    },
-    {
-      second_category_id: '3',
-      third_category: 'ハーフパンツ',
-    },
-    {
-      second_category_id: '3',
-      third_category: 'チノパン',
-    },
-    {
-      second_category_id: '3',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '4',
-      third_category: 'ミニスカート',
-    },
-    {
-      second_category_id: '4',
-      third_category: 'ひざ丈スカート',
-    },
-    {
-      second_category_id: '4',
-      third_category: 'ロングスカート',
-    },
-    {
-      second_category_id: '4',
-      third_category: 'キュロット',
-    },
-    {
-      second_category_id: '4',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '5',
-      third_category: 'ミニワンピース',
-    },
-    {
-      second_category_id: '5',
-      third_category: 'ひざ丈ワンピース',
-    },
-    {
-      second_category_id: '5',
-      third_category: 'ロングワンピース',
-    },
-    {
-      second_category_id: '5',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '6',
-      third_category: 'コスプレ',
-    },
-    {
-      second_category_id: '5',
-      third_category: '下着',
-    },
-    {
-      second_category_id: '5',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '7',
-      third_category: 'Tシャツ/カットソー(半袖/袖なし)',
-    },
-    {
-      second_category_id: '7',
-      third_category: 'Tシャツ/カットソー(七分/長袖)',
-    },
-    {
-      second_category_id: '7',
-      third_category: 'シャツ',
-    },
-    {
-      second_category_id: '7',
-      third_category: 'ポロシャツ',
-    },
-    {
-      second_category_id: '7',
-      third_category: 'タンクトップ',
-    },
-    {
-      second_category_id: '7',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '8',
-      third_category: 'テーラードジャケット',
-    },
-    {
-      second_category_id: '8',
-      third_category: 'ノーカラージャケット',
-    },
-    {
-      second_category_id: '8',
-      third_category: 'Gジャン/デニムジャケット',
-    },
-    {
-      second_category_id: '8',
-      third_category: 'レザージャケット',
-    },
-    {
-      second_category_id: '8',
-      third_category: 'ダウンジャケット',
-    },
-    {
-      second_category_id: '8',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '9',
-      third_category: 'デニム/ジーンズ',
-    },
-    {
-      second_category_id: '9',
-      third_category: 'ワークパンツ/カーゴパンツ',
-    },
-    {
-      second_category_id: '9',
-      third_category: 'スラックス',
-    },
-    {
-      second_category_id: '9',
-      third_category: 'チノパン',
-    },
-    {
-      second_category_id: '9',
-      third_category: 'ショートパンツ',
-    },
-    {
-      second_category_id: '9',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '10',
-      third_category: 'スニーカー',
-    },
-    {
-      second_category_id: '10',
-      third_category: 'サンダル',
-    },
-    {
-      second_category_id: '10',
-      third_category: 'ブーツ',
-    },
-    {
-      second_category_id: '10',
-      third_category: 'モカシン',
-    },
-    {
-      second_category_id: '10',
-      third_category: 'ドレス/ビジネス',
-    },
-    {
-      second_category_id: '10',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '11',
-      third_category: 'ショルダーバッグ',
-    },
-    {
-      second_category_id: '11',
-      third_category: 'トートバッグ',
-    },
-    {
-      second_category_id: '11',
-      third_category: 'ボストンバッグ',
-    },
-    {
-      second_category_id: '11',
-      third_category: 'リュック/バックパック',
-    },
-    {
-      second_category_id: '11',
-      third_category: 'ウエストポーチ',
-    },
-    {
-      second_category_id: '11',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '12',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '13',
-      third_category: 'トップス',
-    },
-    {
-      second_category_id: '13',
-      third_category: 'アウター',
-    },
-    {
-      second_category_id: '13',
-      third_category: 'パンツ',
-    },
-    {
-      second_category_id: '13',
-      third_category: 'スカート',
-    },
-    {
-      second_category_id: '13',
-      third_category: 'ワンピース',
-    },
-    {
-      second_category_id: '13',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '14',
-      third_category: 'トップス',
-    },
-    {
-      second_category_id: '14',
-      third_category: 'アウター',
-    },
-    {
-      second_category_id: '14',
-      third_category: 'パンツ',
-    },
-    {
-      second_category_id: '14',
-      third_category: 'おくるみ',
-    },
-    {
-      second_category_id: '14',
-      third_category: '下着/肌着',
-    },
-    {
-      second_category_id: '14',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '15',
-      third_category: 'トップス',
-    },
-    {
-      second_category_id: '15',
-      third_category: 'アウター',
-    },
-    {
-      second_category_id: '15',
-      third_category: 'パンツ',
-    },
-    {
-      second_category_id: '15',
-      third_category: 'おくるみ',
-    },
-    {
-      second_category_id: '15',
-      third_category: '下着/肌着',
-    },
-    {
-      second_category_id: '15',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '16',
-      third_category: 'コート',
-    },
-    {
-      second_category_id: '16',
-      third_category: 'ジャケット/上着',
-    },
-    {
-      second_category_id: '16',
-      third_category: 'トップス(Tシャツ/カットソー)',
-    },
-    {
-      second_category_id: '16',
-      third_category: 'トップス(トレーナー)',
-    },
-    {
-      second_category_id: '16',
-      third_category: 'トップス(チュニック)',
-    },
-    {
-      second_category_id: '16',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '17',
-      third_category: 'コート',
-    },
-    {
-      second_category_id: '17',
-      third_category: 'ジャケット/上着',
-    },
-    {
-      second_category_id: '17',
-      third_category: 'トップス(Tシャツ/カットソー)',
-    },
-    {
-      second_category_id: '17',
-      third_category: 'トップス(トレーナー)',
-    },
-    {
-      second_category_id: '17',
-      third_category: 'トップス(その他)',
-    },
-    {
-      second_category_id: '17',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '18',
-      third_category: '母子手帳用品',
-    },
-    {
-      second_category_id: '18',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '19',
-      third_category: '食器',
-    },
-    {
-      second_category_id: '19',
-      third_category: '調理器具',
-    },
-    {
-      second_category_id: '19',
-      third_category: '収納/キッチン雑貨',
-    },
-    {
-      second_category_id: '19',
-      third_category: '弁当用品',
-    },
-    {
-      second_category_id: '19',
-      third_category: 'カトラリー(スプーン等)',
-    },
-    {
-      second_category_id: '19',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '20',
-      third_category: 'セミシングルベッド',
-    },
-    {
-      second_category_id: '20',
-      third_category: 'シングルベッド',
-    },
-    {
-      second_category_id: '20',
-      third_category: 'セミダブルベッド',
-    },
-    {
-      second_category_id: '20',
-      third_category: 'ダブルベッド',
-    },
-    {
-      second_category_id: '20',
-      third_category: 'ワイドダブルベッド',
-    },
-    {
-      second_category_id: '20',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '21',
-      third_category: 'ソファセット',
-    },
-    {
-      second_category_id: '21',
-      third_category: 'シングルソファ',
-    },
-    {
-      second_category_id: '21',
-      third_category: 'ラブソファ',
-    },
-    {
-      second_category_id: '21',
-      third_category: 'トリプルソファ',
-    },
-    {
-      second_category_id: '21',
-      third_category: 'オットマン',
-    },
-    {
-      second_category_id: '21',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '22',
-      third_category: '一般',
-    },
-    {
-      second_category_id: '22',
-      third_category: 'スツール',
-    },
-    {
-      second_category_id: '22',
-      third_category: 'ダイニングチェア',
-    },
-    {
-      second_category_id: '22',
-      third_category: 'ハイバックチェア',
-    },
-    {
-      second_category_id: '22',
-      third_category: 'ロッキングチェア',
-    },
-    {
-      second_category_id: '22',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '23',
-      third_category: 'こたつ',
-    },
-    {
-      second_category_id: '23',
-      third_category: 'カウンターテーブル',
-    },
-    {
-      second_category_id: '23',
-      third_category: 'サイドテーブル',
-    },
-    {
-      second_category_id: '23',
-      third_category: 'センターテーブル',
-    },
-    {
-      second_category_id: '23',
-      third_category: 'ダイニングテーブル',
-    },
-    {
-      second_category_id: '23',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '24',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '25',
-      third_category: '文学/小説',
-    },
-    {
-      second_category_id: '25',
-      third_category: '人文/社会',
-    },
-    {
-      second_category_id: '25',
-      third_category: 'ノンフィクション/教養',
-    },
-    {
-      second_category_id: '25',
-      third_category: '地図/旅行ガイド',
-    },
-    {
-      second_category_id: '25',
-      third_category: 'ビジネス/経済',
-    },
-    {
-      second_category_id: '25',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '26',
-      third_category: '全巻セット',
-    },
-    {
-      second_category_id: '26',
-      third_category: '少年漫画',
-    },
-    {
-      second_category_id: '26',
-      third_category: '少女漫画',
-    },
-    {
-      second_category_id: '26',
-      third_category: '青年漫画',
-    },
-    {
-      second_category_id: '26',
-      third_category: '女性漫画',
-    },
-    {
-      second_category_id: '26',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '27',
-      third_category: 'アート/エンタメ/ホビー',
-    },
-    {
-      second_category_id: '27',
-      third_category: 'ファッション',
-    },
-    {
-      second_category_id: '27',
-      third_category: 'ニュース/総合',
-    },
-    {
-      second_category_id: '27',
-      third_category: '趣味/スポーツ',
-    },
-    {
-      second_category_id: '27',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '28',
-      third_category: '邦楽',
-    },
-    {
-      second_category_id: '28',
-      third_category: '洋楽',
-    },
-    {
-      second_category_id: '28',
-      third_category: 'アニメ',
-    },
-    {
-      second_category_id: '28',
-      third_category: 'クラシック',
-    },
-    {
-      second_category_id: '28',
-      third_category: 'K-POP/アジア',
-    },
-    {
-      second_category_id: '28',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '29',
-      third_category: '外国映画',
-    },
-    {
-      second_category_id: '29',
-      third_category: '日本映画',
-    },
-    {
-      second_category_id: '29',
-      third_category: 'アニメ',
-    },
-    {
-      second_category_id: '29',
-      third_category: 'TVドラマ',
-    },
-    {
-      second_category_id: '29',
-      third_category: 'ミュージック',
-    },
-    {
-      second_category_id: '29',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '30',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '31',
-      third_category: 'キャラクターグッズ',
-    },
-    {
-      second_category_id: '31',
-      third_category: 'ぬいぐるみ',
-    },
-    {
-      second_category_id: '31',
-      third_category: '小物/アクセサリー',
-    },
-    {
-      second_category_id: '31',
-      third_category: '模型/プラモデル',
-    },
-    {
-      second_category_id: '31',
-      third_category: 'ミニカー',
-    },
-    {
-      second_category_id: '31',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '32',
-      third_category: 'アイドル',
-    },
-    {
-      second_category_id: '32',
-      third_category: 'ミュージシャン',
-    },
-    {
-      second_category_id: '32',
-      third_category: 'タレント/お笑い芸人',
-    },
-    {
-      second_category_id: '32',
-      third_category: 'スポーツ選手',
-    },
-    {
-      second_category_id: '32',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '33',
-      third_category: 'ストラップ',
-    },
-    {
-      second_category_id: '33',
-      third_category: 'キーホルダー',
-    },
-    {
-      second_category_id: '33',
-      third_category: 'バッジ',
-    },
-    {
-      second_category_id: '33',
-      third_category: 'カード',
-    },
-    {
-      second_category_id: '33',
-      third_category: 'クリアファイル',
-    },
-    {
-      second_category_id: '33',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '34',
-      third_category: '遊戯王',
-    },
-    {
-      second_category_id: '34',
-      third_category: 'マジック:ザ・ギャザリング',
-    },
-    {
-      second_category_id: '34',
-      third_category: 'ポケモンカードゲーム',
-    },
-    {
-      second_category_id: '34',
-      third_category: 'デュエルマスターズ',
-    },
-    {
-      second_category_id: '34',
-      third_category: 'バトルスピリッツ',
-    },
-    {
-      second_category_id: '34',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '35',
-      third_category: 'コミック/アニメ',
-    },
-    {
-      second_category_id: '35',
-      third_category: '特撮',
-    },
-    {
-      second_category_id: '35',
-      third_category: 'ゲームキャラクター',
-    },
-    {
-      second_category_id: '35',
-      third_category: 'SF/ファンタジー/ホラー',
-    },
-    {
-      second_category_id: '35',
-      third_category: 'アメコミ',
-    },
-    {
-      second_category_id: '35',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '36',
-      third_category: 'トランプ',
-    },
-    {
-      second_category_id: '36',
-      third_category: 'カルタ/百人一首',
-    },
-    {
-      second_category_id: '36',
-      third_category: 'ダーツ',
-    },
-    {
-      second_category_id: '36',
-      third_category: 'ビリヤード',
-    },
-    {
-      second_category_id: '36',
-      third_category: '麻雀',
-    },
-    {
-      second_category_id: '36',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '37',
-      third_category: 'ファンデーション',
-    },
-    {
-      second_category_id: '37',
-      third_category: '化粧下地',
-    },
-    {
-      second_category_id: '37',
-      third_category: 'コントロールカラー',
-    },
-    {
-      second_category_id: '37',
-      third_category: 'BBクリーム',
-    },
-    {
-      second_category_id: '37',
-      third_category: 'CCクリーム',
-    },
-    {
-      second_category_id: '37',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '38',
-      third_category: 'アイシャドウ',
-    },
-    {
-      second_category_id: '38',
-      third_category: '口紅',
-    },
-    {
-      second_category_id: '38',
-      third_category: 'リップグロス',
-    },
-    {
-      second_category_id: '38',
-      third_category: 'リップライナー',
-    },
-    {
-      second_category_id: '38',
-      third_category: 'チーク',
-    },
-    {
-      second_category_id: '38',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '39',
-      third_category: 'ネイルカラー',
-    },
-    {
-      second_category_id: '39',
-      third_category: 'カラージェル',
-    },
-    {
-      second_category_id: '39',
-      third_category: 'ネイルベースコート/トップコート',
-    },
-    {
-      second_category_id: '39',
-      third_category: 'ネイルアート用品',
-    },
-    {
-      second_category_id: '39',
-      third_category: 'ネイルパーツ',
-    },
-    {
-      second_category_id: '39',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '40',
-      third_category: '香水(女性用)',
-    },
-    {
-      second_category_id: '40',
-      third_category: '香水(男性用)',
-    },
-    {
-      second_category_id: '40',
-      third_category: 'ユニセックス',
-    },
-    {
-      second_category_id: '40',
-      third_category: 'ボディミスト',
-    },
-    {
-      second_category_id: '40',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '41',
-      third_category: '化粧水/ローション',
-    },
-    {
-      second_category_id: '41',
-      third_category: '乳液/ミルク',
-    },
-    {
-      second_category_id: '41',
-      third_category: '美容液',
-    },
-    {
-      second_category_id: '41',
-      third_category: 'フェイスクリーム',
-    },
-    {
-      second_category_id: '41',
-      third_category: '洗顔料',
-    },
-    {
-      second_category_id: '41',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '42',
-      third_category: '健康用品',
-    },
-    {
-      second_category_id: '42',
-      third_category: '看護/介護用品',
-    },
-    {
-      second_category_id: '42',
-      third_category: '救急/衛生用品',
-    },
-    {
-      second_category_id: '42',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '43',
-      third_category: 'スマートフォン本体',
-    },
-    {
-      second_category_id: '43',
-      third_category: 'バッテリー/充電器',
-    },
-    {
-      second_category_id: '43',
-      third_category: '携帯電話本体',
-    },
-    {
-      second_category_id: '43',
-      third_category: 'PHS本体',
-    },
-    {
-      second_category_id: '43',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '44',
-      third_category: 'Android用ケース',
-    },
-    {
-      second_category_id: '44',
-      third_category: 'iPhone用ケース',
-    },
-    {
-      second_category_id: '44',
-      third_category: 'カバー',
-    },
-    {
-      second_category_id: '44',
-      third_category: 'イヤホンジャック',
-    },
-    {
-      second_category_id: '44',
-      third_category: 'ストラップ',
-    },
-    {
-      second_category_id: '44',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '45',
-      third_category: 'タブレット',
-    },
-    {
-      second_category_id: '45',
-      third_category: 'ノートPC',
-    },
-    {
-      second_category_id: '45',
-      third_category: 'デスクトップ型PC',
-    },
-    {
-      second_category_id: '45',
-      third_category: 'ディスプレイ',
-    },
-    {
-      second_category_id: '45',
-      third_category: '電子ブックリーダー',
-    },
-    {
-      second_category_id: '45',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '46',
-      third_category: 'デジタルカメラ',
-    },
-    {
-      second_category_id: '46',
-      third_category: 'ビデオカメラ',
-    },
-    {
-      second_category_id: '46',
-      third_category: 'レンズ(単焦点)',
-    },
-    {
-      second_category_id: '46',
-      third_category: 'レンズ(ズーム)',
-    },
-    {
-      second_category_id: '46',
-      third_category: 'フィルムカメラ',
-    },
-    {
-      second_category_id: '46',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '47',
-      third_category: 'テレビ',
-    },
-    {
-      second_category_id: '47',
-      third_category: 'プロジェクター',
-    },
-    {
-      second_category_id: '47',
-      third_category: 'ブルーレイレコーダー',
-    },
-    {
-      second_category_id: '47',
-      third_category: 'DVDレコーダー',
-    },
-    {
-      second_category_id: '47',
-      third_category: 'ブルーレイプレーヤー',
-    },
-    {
-      second_category_id: '47',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '48',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '49',
-      third_category: 'クラブ',
-    },
-    {
-      second_category_id: '49',
-      third_category: 'ウェア(男性用)',
-    },
-    {
-      second_category_id: '49',
-      third_category: 'ウェア(女性用)',
-    },
-    {
-      second_category_id: '49',
-      third_category: 'バッグ',
-    },
-    {
-      second_category_id: '49',
-      third_category: 'シューズ(男性用)',
-    },
-    {
-      second_category_id: '49',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '50',
-      third_category: 'ロッド',
-    },
-    {
-      second_category_id: '50',
-      third_category: 'リール',
-    },
-    {
-      second_category_id: '50',
-      third_category: 'ルアー用品',
-    },
-    {
-      second_category_id: '50',
-      third_category: 'ウェア',
-    },
-    {
-      second_category_id: '50',
-      third_category: '釣り糸/ライン',
-    },
-    {
-      second_category_id: '50',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '51',
-      third_category: '自転車本体',
-    },
-    {
-      second_category_id: '51',
-      third_category: 'ウェア',
-    },
-    {
-      second_category_id: '51',
-      third_category: 'パーツ',
-    },
-    {
-      second_category_id: '51',
-      third_category: 'アクセサリー',
-    },
-    {
-      second_category_id: '51',
-      third_category: 'バッグ',
-    },
-    {
-      second_category_id: '51',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '52',
-      third_category: 'ランニング',
-    },
-    {
-      second_category_id: '52',
-      third_category: 'ウォーキング',
-    },
-    {
-      second_category_id: '52',
-      third_category: 'ヨガ',
-    },
-    {
-      second_category_id: '52',
-      third_category: 'トレーニング用品',
-    },
-    {
-      second_category_id: '52',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '53',
-      third_category: 'ウェア',
-    },
-    {
-      second_category_id: '53',
-      third_category: 'シューズ',
-    },
-    {
-      second_category_id: '53',
-      third_category: 'グローブ',
-    },
-    {
-      second_category_id: '53',
-      third_category: 'バット',
-    },
-    {
-      second_category_id: '53',
-      third_category: 'アクセサリー',
-    },
-    {
-      second_category_id: '53',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '54',
-      third_category: '旅行用品',
-    },
-    {
-      second_category_id: '54',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '55',
-      third_category: 'ピアス',
-    },
-    {
-      second_category_id: '55',
-      third_category: 'イヤリング',
-    },
-    {
-      second_category_id: '55',
-      third_category: 'ネックレス',
-    },
-    {
-      second_category_id: '55',
-      third_category: 'ブレスレット',
-    },
-    {
-      second_category_id: '55',
-      third_category: 'リング',
-    },
-    {
-      second_category_id: '55',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '56',
-      third_category: 'バッグ(女性用)',
-    },
-    {
-      second_category_id: '56',
-      third_category: 'バッグ(男性用)',
-    },
-    {
-      second_category_id: '56',
-      third_category: '財布(女性用)',
-    },
-    {
-      second_category_id: '56',
-      third_category: '財布(男性用)',
-    },
-    {
-      second_category_id: '56',
-      third_category: 'ファッション雑誌',
-    },
-    {
-      second_category_id: '56',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '57',
-      third_category: 'アクセサリー(男性用)',
-    },
-    {
-      second_category_id: '57',
-      third_category: '時計(女性用)',
-    },
-    {
-      second_category_id: '57',
-      third_category: '時計(男性用)',
-    },
-    {
-      second_category_id: '57',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '58',
-      third_category: 'キッチン用品',
-    },
-    {
-      second_category_id: '58',
-      third_category: '家具',
-    },
-    {
-      second_category_id: '58',
-      third_category: '文房具',
-    },
-    {
-      second_category_id: '58',
-      third_category: 'アート/写真',
-    },
-    {
-      second_category_id: '58',
-      third_category: 'アロマ/キャンドル',
-    },
-    {
-      second_category_id: '58',
-      third_category: 'その他',
-    }, 
-    {
-      second_category_id: '59',
-      third_category: 'クラフト/布製品',
-    },
-    {
-      second_category_id: '59',
-      third_category: 'おもちゃ/人形',
-    },
-    {
-      second_category_id: '59',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '60',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '61',
-      third_category: '男性アイドル',
-    },
-    {
-      second_category_id: '61',
-      third_category: '女性アイドル',
-    },
-    {
-      second_category_id: '61',
-      third_category: '韓流',
-    },
-    {
-      second_category_id: '61',
-      third_category: '国内アーティスト',
-    },
-    {
-      second_category_id: '61',
-      third_category: '海外アーティスト',
-    },
-    {
-      second_category_id: '61',
-      third_category: 'その他',
-    }, 
-    {
-      second_category_id: '62',
-      third_category: 'サッカー',
-    },
-    {
-      second_category_id: '62',
-      third_category: '野球',
-    },
-    {
-      second_category_id: '62',
-      third_category: 'テニス',
-    },
-    {
-      second_category_id: '62',
-      third_category: '格闘技/プロレス',
-    },
-    {
-      second_category_id: '62',
-      third_category: '相撲/武道',
-    },
-    {
-      second_category_id: '62',
-      third_category: 'その他',
-    }, 
-    {
-      second_category_id: '63',
-      third_category: 'ミュージカル',
-    },
-    {
-      second_category_id: '63',
-      third_category: '演劇',
-    },
-    {
-      second_category_id: '63',
-      third_category: '伝統芸能',
-    },
-    {
-      second_category_id: '63',
-      third_category: '落語',
-    },
-    {
-      second_category_id: '63',
-      third_category: 'お笑い',
-    },
-    {
-      second_category_id: '63',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '64',
-      third_category: '声優/アニメ',
-    },
-    {
-      second_category_id: '64',
-      third_category: 'キッズ/ファミリー',
-    },
-    {
-      second_category_id: '64',
-      third_category: 'トークショー/講演会',
-    },
-    {
-      second_category_id: '64',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '65',
-      third_category: '邦画',
-    },
-    {
-      second_category_id: '65',
-      third_category: '洋画',
-    },
-    {
-      second_category_id: '65',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '66',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '67',
-      third_category: '国内自動車本体',
-    },
-    {
-      second_category_id: '67',
-      third_category: '外国自動車本体',
-    },
-    {
-      second_category_id: '68',
-      third_category: 'タイヤ/ホイールセット',
-    },
-    {
-      second_category_id: '68',
-      third_category: 'タイヤ',
-    },
-    {
-      second_category_id: '68',
-      third_category: 'ホイール',
-    },
-    {
-      second_category_id: '68',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '69',
-      third_category: 'サスペンション',
-    },
-    {
-      second_category_id: '69',
-      third_category: 'ブレーキ',
-    },
-    {
-      second_category_id: '69',
-      third_category: '外装/エアロパーツ',
-    },
-    {
-      second_category_id: '69',
-      third_category: 'ライト',
-    },
-    {
-      second_category_id: '69',
-      third_category: '内装品/シート',
-    },
-    {
-      second_category_id: '69',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '70',
-      third_category: '車内アクセサリー',
-    },
-    {
-      second_category_id: '70',
-      third_category: 'カーナビ',
-    },
-    {
-      second_category_id: '70',
-      third_category: 'カーオーディオ',
-    },
-    {
-      second_category_id: '70',
-      third_category: '車外アクセサリー',
-    },
-    {
-      second_category_id: '70',
-      third_category: 'メンテナンス用品',
-    },
-    {
-      second_category_id: '70',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '71',
-      third_category: 'オートバイ本体',
-    },
-    {
-      second_category_id: '72',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '73',
-      third_category: 'まとめ売り',
-    },
-    {
-      second_category_id: '74',
-      third_category: 'ペットフード',
-    },
-    {
-      second_category_id: '74',
-      third_category: '犬用品',
-    },
-    {
-      second_category_id: '74',
-      third_category: '猫用品',
-    },
-    {
-      second_category_id: '74',
-      third_category: '魚用品/水草',
-    },
-    {
-      second_category_id: '74',
-      third_category: '小動物用品',
-    },
-    {
-      second_category_id: '74',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '75',
-      third_category: '菓子',
-    },
-    {
-      second_category_id: '75',
-      third_category: '米',
-    },
-    {
-      second_category_id: '75',
-      third_category: '野菜',
-    },
-    {
-      second_category_id: '75',
-      third_category: '果物',
-    },
-    {
-      second_category_id: '75',
-      third_category: '調味料',
-    },
-    {
-      second_category_id: '75',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '76',
-      third_category: 'コーヒー',
-    },
-    {
-      second_category_id: '76',
-      third_category: 'ソフトドリンク',
-    },
-    {
-      second_category_id: '76',
-      third_category: 'ミネラルウォーター',
-    },
-    {
-      second_category_id: '76',
-      third_category: '茶',
-    },
-    {
-      second_category_id: '76',
-      third_category: 'ウイスキー',
-    },
-    {
-      second_category_id: '76',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '77',
-      third_category: 'タオル/バス用品',
-    },
-    {
-      second_category_id: '77',
-      third_category: '日用品/生活雑貨',
-    },
-    {
-      second_category_id: '77',
-      third_category: '洗剤/柔軟剤',
-    },
-    {
-      second_category_id: '77',
-      third_category: '旅行用品',
-    },
-    {
-      second_category_id: '77',
-      third_category: '防災関連グッズ',
-    },
-    {
-      second_category_id: '77',
-      third_category: 'その他',
-    },
-    {
-      second_category_id: '78',
-      third_category: 'その他',
-    },
-  ]
-)
+# ThirdCategory.create!(
+#   [
+#     {
+#       second_category_id: '1',
+#       third_category: 'Tシャツ/カットソー(半袖/袖なし)',
+#     },
+#     {
+#       second_category_id: '1',
+#       third_category: 'Tシャツ/カットソー(七分/長袖)',
+#     },
+#     {
+#       second_category_id: '1',
+#       third_category: 'シャツ/ブラウス(半袖/袖なし)',
+#     },
+#     {
+#       second_category_id: '1',
+#       third_category: 'シャツ/ブラウス(七分/長袖)',
+#     },
+#     {
+#       second_category_id: '1',
+#       third_category: 'ポロシャツ',
+#     },
+#     {
+#       second_category_id: '1',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '2',
+#       third_category: 'テーラードジャケット',
+#     },
+#     {
+#       second_category_id: '2',
+#       third_category: 'ノーカラージャケット',
+#     },
+#     {
+#       second_category_id: '2',
+#       third_category: 'Gジャン/デニムジャケット',
+#     },
+#     {
+#       second_category_id: '2',
+#       third_category: 'レザージャケット',
+#     },
+#     {
+#       second_category_id: '2',
+#       third_category: 'ダウンジャケット',
+#     },
+#     {
+#       second_category_id: '2',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '3',
+#       third_category: 'デニム/ジーンズ',
+#     },
+#     {
+#       second_category_id: '3',
+#       third_category: 'ショートパンツ',
+#     },
+#     {
+#       second_category_id: '3',
+#       third_category: 'カジュアルパンツ',
+#     },
+#     {
+#       second_category_id: '3',
+#       third_category: 'ハーフパンツ',
+#     },
+#     {
+#       second_category_id: '3',
+#       third_category: 'チノパン',
+#     },
+#     {
+#       second_category_id: '3',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '4',
+#       third_category: 'ミニスカート',
+#     },
+#     {
+#       second_category_id: '4',
+#       third_category: 'ひざ丈スカート',
+#     },
+#     {
+#       second_category_id: '4',
+#       third_category: 'ロングスカート',
+#     },
+#     {
+#       second_category_id: '4',
+#       third_category: 'キュロット',
+#     },
+#     {
+#       second_category_id: '4',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '5',
+#       third_category: 'ミニワンピース',
+#     },
+#     {
+#       second_category_id: '5',
+#       third_category: 'ひざ丈ワンピース',
+#     },
+#     {
+#       second_category_id: '5',
+#       third_category: 'ロングワンピース',
+#     },
+#     {
+#       second_category_id: '5',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '6',
+#       third_category: 'コスプレ',
+#     },
+#     {
+#       second_category_id: '5',
+#       third_category: '下着',
+#     },
+#     {
+#       second_category_id: '5',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '7',
+#       third_category: 'Tシャツ/カットソー(半袖/袖なし)',
+#     },
+#     {
+#       second_category_id: '7',
+#       third_category: 'Tシャツ/カットソー(七分/長袖)',
+#     },
+#     {
+#       second_category_id: '7',
+#       third_category: 'シャツ',
+#     },
+#     {
+#       second_category_id: '7',
+#       third_category: 'ポロシャツ',
+#     },
+#     {
+#       second_category_id: '7',
+#       third_category: 'タンクトップ',
+#     },
+#     {
+#       second_category_id: '7',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '8',
+#       third_category: 'テーラードジャケット',
+#     },
+#     {
+#       second_category_id: '8',
+#       third_category: 'ノーカラージャケット',
+#     },
+#     {
+#       second_category_id: '8',
+#       third_category: 'Gジャン/デニムジャケット',
+#     },
+#     {
+#       second_category_id: '8',
+#       third_category: 'レザージャケット',
+#     },
+#     {
+#       second_category_id: '8',
+#       third_category: 'ダウンジャケット',
+#     },
+#     {
+#       second_category_id: '8',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '9',
+#       third_category: 'デニム/ジーンズ',
+#     },
+#     {
+#       second_category_id: '9',
+#       third_category: 'ワークパンツ/カーゴパンツ',
+#     },
+#     {
+#       second_category_id: '9',
+#       third_category: 'スラックス',
+#     },
+#     {
+#       second_category_id: '9',
+#       third_category: 'チノパン',
+#     },
+#     {
+#       second_category_id: '9',
+#       third_category: 'ショートパンツ',
+#     },
+#     {
+#       second_category_id: '9',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '10',
+#       third_category: 'スニーカー',
+#     },
+#     {
+#       second_category_id: '10',
+#       third_category: 'サンダル',
+#     },
+#     {
+#       second_category_id: '10',
+#       third_category: 'ブーツ',
+#     },
+#     {
+#       second_category_id: '10',
+#       third_category: 'モカシン',
+#     },
+#     {
+#       second_category_id: '10',
+#       third_category: 'ドレス/ビジネス',
+#     },
+#     {
+#       second_category_id: '10',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '11',
+#       third_category: 'ショルダーバッグ',
+#     },
+#     {
+#       second_category_id: '11',
+#       third_category: 'トートバッグ',
+#     },
+#     {
+#       second_category_id: '11',
+#       third_category: 'ボストンバッグ',
+#     },
+#     {
+#       second_category_id: '11',
+#       third_category: 'リュック/バックパック',
+#     },
+#     {
+#       second_category_id: '11',
+#       third_category: 'ウエストポーチ',
+#     },
+#     {
+#       second_category_id: '11',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '12',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '13',
+#       third_category: 'トップス',
+#     },
+#     {
+#       second_category_id: '13',
+#       third_category: 'アウター',
+#     },
+#     {
+#       second_category_id: '13',
+#       third_category: 'パンツ',
+#     },
+#     {
+#       second_category_id: '13',
+#       third_category: 'スカート',
+#     },
+#     {
+#       second_category_id: '13',
+#       third_category: 'ワンピース',
+#     },
+#     {
+#       second_category_id: '13',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '14',
+#       third_category: 'トップス',
+#     },
+#     {
+#       second_category_id: '14',
+#       third_category: 'アウター',
+#     },
+#     {
+#       second_category_id: '14',
+#       third_category: 'パンツ',
+#     },
+#     {
+#       second_category_id: '14',
+#       third_category: 'おくるみ',
+#     },
+#     {
+#       second_category_id: '14',
+#       third_category: '下着/肌着',
+#     },
+#     {
+#       second_category_id: '14',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '15',
+#       third_category: 'トップス',
+#     },
+#     {
+#       second_category_id: '15',
+#       third_category: 'アウター',
+#     },
+#     {
+#       second_category_id: '15',
+#       third_category: 'パンツ',
+#     },
+#     {
+#       second_category_id: '15',
+#       third_category: 'おくるみ',
+#     },
+#     {
+#       second_category_id: '15',
+#       third_category: '下着/肌着',
+#     },
+#     {
+#       second_category_id: '15',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '16',
+#       third_category: 'コート',
+#     },
+#     {
+#       second_category_id: '16',
+#       third_category: 'ジャケット/上着',
+#     },
+#     {
+#       second_category_id: '16',
+#       third_category: 'トップス(Tシャツ/カットソー)',
+#     },
+#     {
+#       second_category_id: '16',
+#       third_category: 'トップス(トレーナー)',
+#     },
+#     {
+#       second_category_id: '16',
+#       third_category: 'トップス(チュニック)',
+#     },
+#     {
+#       second_category_id: '16',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '17',
+#       third_category: 'コート',
+#     },
+#     {
+#       second_category_id: '17',
+#       third_category: 'ジャケット/上着',
+#     },
+#     {
+#       second_category_id: '17',
+#       third_category: 'トップス(Tシャツ/カットソー)',
+#     },
+#     {
+#       second_category_id: '17',
+#       third_category: 'トップス(トレーナー)',
+#     },
+#     {
+#       second_category_id: '17',
+#       third_category: 'トップス(その他)',
+#     },
+#     {
+#       second_category_id: '17',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '18',
+#       third_category: '母子手帳用品',
+#     },
+#     {
+#       second_category_id: '18',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '19',
+#       third_category: '食器',
+#     },
+#     {
+#       second_category_id: '19',
+#       third_category: '調理器具',
+#     },
+#     {
+#       second_category_id: '19',
+#       third_category: '収納/キッチン雑貨',
+#     },
+#     {
+#       second_category_id: '19',
+#       third_category: '弁当用品',
+#     },
+#     {
+#       second_category_id: '19',
+#       third_category: 'カトラリー(スプーン等)',
+#     },
+#     {
+#       second_category_id: '19',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '20',
+#       third_category: 'セミシングルベッド',
+#     },
+#     {
+#       second_category_id: '20',
+#       third_category: 'シングルベッド',
+#     },
+#     {
+#       second_category_id: '20',
+#       third_category: 'セミダブルベッド',
+#     },
+#     {
+#       second_category_id: '20',
+#       third_category: 'ダブルベッド',
+#     },
+#     {
+#       second_category_id: '20',
+#       third_category: 'ワイドダブルベッド',
+#     },
+#     {
+#       second_category_id: '20',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '21',
+#       third_category: 'ソファセット',
+#     },
+#     {
+#       second_category_id: '21',
+#       third_category: 'シングルソファ',
+#     },
+#     {
+#       second_category_id: '21',
+#       third_category: 'ラブソファ',
+#     },
+#     {
+#       second_category_id: '21',
+#       third_category: 'トリプルソファ',
+#     },
+#     {
+#       second_category_id: '21',
+#       third_category: 'オットマン',
+#     },
+#     {
+#       second_category_id: '21',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '22',
+#       third_category: '一般',
+#     },
+#     {
+#       second_category_id: '22',
+#       third_category: 'スツール',
+#     },
+#     {
+#       second_category_id: '22',
+#       third_category: 'ダイニングチェア',
+#     },
+#     {
+#       second_category_id: '22',
+#       third_category: 'ハイバックチェア',
+#     },
+#     {
+#       second_category_id: '22',
+#       third_category: 'ロッキングチェア',
+#     },
+#     {
+#       second_category_id: '22',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '23',
+#       third_category: 'こたつ',
+#     },
+#     {
+#       second_category_id: '23',
+#       third_category: 'カウンターテーブル',
+#     },
+#     {
+#       second_category_id: '23',
+#       third_category: 'サイドテーブル',
+#     },
+#     {
+#       second_category_id: '23',
+#       third_category: 'センターテーブル',
+#     },
+#     {
+#       second_category_id: '23',
+#       third_category: 'ダイニングテーブル',
+#     },
+#     {
+#       second_category_id: '23',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '24',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '25',
+#       third_category: '文学/小説',
+#     },
+#     {
+#       second_category_id: '25',
+#       third_category: '人文/社会',
+#     },
+#     {
+#       second_category_id: '25',
+#       third_category: 'ノンフィクション/教養',
+#     },
+#     {
+#       second_category_id: '25',
+#       third_category: '地図/旅行ガイド',
+#     },
+#     {
+#       second_category_id: '25',
+#       third_category: 'ビジネス/経済',
+#     },
+#     {
+#       second_category_id: '25',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '26',
+#       third_category: '全巻セット',
+#     },
+#     {
+#       second_category_id: '26',
+#       third_category: '少年漫画',
+#     },
+#     {
+#       second_category_id: '26',
+#       third_category: '少女漫画',
+#     },
+#     {
+#       second_category_id: '26',
+#       third_category: '青年漫画',
+#     },
+#     {
+#       second_category_id: '26',
+#       third_category: '女性漫画',
+#     },
+#     {
+#       second_category_id: '26',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '27',
+#       third_category: 'アート/エンタメ/ホビー',
+#     },
+#     {
+#       second_category_id: '27',
+#       third_category: 'ファッション',
+#     },
+#     {
+#       second_category_id: '27',
+#       third_category: 'ニュース/総合',
+#     },
+#     {
+#       second_category_id: '27',
+#       third_category: '趣味/スポーツ',
+#     },
+#     {
+#       second_category_id: '27',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '28',
+#       third_category: '邦楽',
+#     },
+#     {
+#       second_category_id: '28',
+#       third_category: '洋楽',
+#     },
+#     {
+#       second_category_id: '28',
+#       third_category: 'アニメ',
+#     },
+#     {
+#       second_category_id: '28',
+#       third_category: 'クラシック',
+#     },
+#     {
+#       second_category_id: '28',
+#       third_category: 'K-POP/アジア',
+#     },
+#     {
+#       second_category_id: '28',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '29',
+#       third_category: '外国映画',
+#     },
+#     {
+#       second_category_id: '29',
+#       third_category: '日本映画',
+#     },
+#     {
+#       second_category_id: '29',
+#       third_category: 'アニメ',
+#     },
+#     {
+#       second_category_id: '29',
+#       third_category: 'TVドラマ',
+#     },
+#     {
+#       second_category_id: '29',
+#       third_category: 'ミュージック',
+#     },
+#     {
+#       second_category_id: '29',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '30',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '31',
+#       third_category: 'キャラクターグッズ',
+#     },
+#     {
+#       second_category_id: '31',
+#       third_category: 'ぬいぐるみ',
+#     },
+#     {
+#       second_category_id: '31',
+#       third_category: '小物/アクセサリー',
+#     },
+#     {
+#       second_category_id: '31',
+#       third_category: '模型/プラモデル',
+#     },
+#     {
+#       second_category_id: '31',
+#       third_category: 'ミニカー',
+#     },
+#     {
+#       second_category_id: '31',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '32',
+#       third_category: 'アイドル',
+#     },
+#     {
+#       second_category_id: '32',
+#       third_category: 'ミュージシャン',
+#     },
+#     {
+#       second_category_id: '32',
+#       third_category: 'タレント/お笑い芸人',
+#     },
+#     {
+#       second_category_id: '32',
+#       third_category: 'スポーツ選手',
+#     },
+#     {
+#       second_category_id: '32',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '33',
+#       third_category: 'ストラップ',
+#     },
+#     {
+#       second_category_id: '33',
+#       third_category: 'キーホルダー',
+#     },
+#     {
+#       second_category_id: '33',
+#       third_category: 'バッジ',
+#     },
+#     {
+#       second_category_id: '33',
+#       third_category: 'カード',
+#     },
+#     {
+#       second_category_id: '33',
+#       third_category: 'クリアファイル',
+#     },
+#     {
+#       second_category_id: '33',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '34',
+#       third_category: '遊戯王',
+#     },
+#     {
+#       second_category_id: '34',
+#       third_category: 'マジック:ザ・ギャザリング',
+#     },
+#     {
+#       second_category_id: '34',
+#       third_category: 'ポケモンカードゲーム',
+#     },
+#     {
+#       second_category_id: '34',
+#       third_category: 'デュエルマスターズ',
+#     },
+#     {
+#       second_category_id: '34',
+#       third_category: 'バトルスピリッツ',
+#     },
+#     {
+#       second_category_id: '34',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '35',
+#       third_category: 'コミック/アニメ',
+#     },
+#     {
+#       second_category_id: '35',
+#       third_category: '特撮',
+#     },
+#     {
+#       second_category_id: '35',
+#       third_category: 'ゲームキャラクター',
+#     },
+#     {
+#       second_category_id: '35',
+#       third_category: 'SF/ファンタジー/ホラー',
+#     },
+#     {
+#       second_category_id: '35',
+#       third_category: 'アメコミ',
+#     },
+#     {
+#       second_category_id: '35',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '36',
+#       third_category: 'トランプ',
+#     },
+#     {
+#       second_category_id: '36',
+#       third_category: 'カルタ/百人一首',
+#     },
+#     {
+#       second_category_id: '36',
+#       third_category: 'ダーツ',
+#     },
+#     {
+#       second_category_id: '36',
+#       third_category: 'ビリヤード',
+#     },
+#     {
+#       second_category_id: '36',
+#       third_category: '麻雀',
+#     },
+#     {
+#       second_category_id: '36',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '37',
+#       third_category: 'ファンデーション',
+#     },
+#     {
+#       second_category_id: '37',
+#       third_category: '化粧下地',
+#     },
+#     {
+#       second_category_id: '37',
+#       third_category: 'コントロールカラー',
+#     },
+#     {
+#       second_category_id: '37',
+#       third_category: 'BBクリーム',
+#     },
+#     {
+#       second_category_id: '37',
+#       third_category: 'CCクリーム',
+#     },
+#     {
+#       second_category_id: '37',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '38',
+#       third_category: 'アイシャドウ',
+#     },
+#     {
+#       second_category_id: '38',
+#       third_category: '口紅',
+#     },
+#     {
+#       second_category_id: '38',
+#       third_category: 'リップグロス',
+#     },
+#     {
+#       second_category_id: '38',
+#       third_category: 'リップライナー',
+#     },
+#     {
+#       second_category_id: '38',
+#       third_category: 'チーク',
+#     },
+#     {
+#       second_category_id: '38',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '39',
+#       third_category: 'ネイルカラー',
+#     },
+#     {
+#       second_category_id: '39',
+#       third_category: 'カラージェル',
+#     },
+#     {
+#       second_category_id: '39',
+#       third_category: 'ネイルベースコート/トップコート',
+#     },
+#     {
+#       second_category_id: '39',
+#       third_category: 'ネイルアート用品',
+#     },
+#     {
+#       second_category_id: '39',
+#       third_category: 'ネイルパーツ',
+#     },
+#     {
+#       second_category_id: '39',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '40',
+#       third_category: '香水(女性用)',
+#     },
+#     {
+#       second_category_id: '40',
+#       third_category: '香水(男性用)',
+#     },
+#     {
+#       second_category_id: '40',
+#       third_category: 'ユニセックス',
+#     },
+#     {
+#       second_category_id: '40',
+#       third_category: 'ボディミスト',
+#     },
+#     {
+#       second_category_id: '40',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '41',
+#       third_category: '化粧水/ローション',
+#     },
+#     {
+#       second_category_id: '41',
+#       third_category: '乳液/ミルク',
+#     },
+#     {
+#       second_category_id: '41',
+#       third_category: '美容液',
+#     },
+#     {
+#       second_category_id: '41',
+#       third_category: 'フェイスクリーム',
+#     },
+#     {
+#       second_category_id: '41',
+#       third_category: '洗顔料',
+#     },
+#     {
+#       second_category_id: '41',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '42',
+#       third_category: '健康用品',
+#     },
+#     {
+#       second_category_id: '42',
+#       third_category: '看護/介護用品',
+#     },
+#     {
+#       second_category_id: '42',
+#       third_category: '救急/衛生用品',
+#     },
+#     {
+#       second_category_id: '42',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '43',
+#       third_category: 'スマートフォン本体',
+#     },
+#     {
+#       second_category_id: '43',
+#       third_category: 'バッテリー/充電器',
+#     },
+#     {
+#       second_category_id: '43',
+#       third_category: '携帯電話本体',
+#     },
+#     {
+#       second_category_id: '43',
+#       third_category: 'PHS本体',
+#     },
+#     {
+#       second_category_id: '43',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '44',
+#       third_category: 'Android用ケース',
+#     },
+#     {
+#       second_category_id: '44',
+#       third_category: 'iPhone用ケース',
+#     },
+#     {
+#       second_category_id: '44',
+#       third_category: 'カバー',
+#     },
+#     {
+#       second_category_id: '44',
+#       third_category: 'イヤホンジャック',
+#     },
+#     {
+#       second_category_id: '44',
+#       third_category: 'ストラップ',
+#     },
+#     {
+#       second_category_id: '44',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '45',
+#       third_category: 'タブレット',
+#     },
+#     {
+#       second_category_id: '45',
+#       third_category: 'ノートPC',
+#     },
+#     {
+#       second_category_id: '45',
+#       third_category: 'デスクトップ型PC',
+#     },
+#     {
+#       second_category_id: '45',
+#       third_category: 'ディスプレイ',
+#     },
+#     {
+#       second_category_id: '45',
+#       third_category: '電子ブックリーダー',
+#     },
+#     {
+#       second_category_id: '45',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '46',
+#       third_category: 'デジタルカメラ',
+#     },
+#     {
+#       second_category_id: '46',
+#       third_category: 'ビデオカメラ',
+#     },
+#     {
+#       second_category_id: '46',
+#       third_category: 'レンズ(単焦点)',
+#     },
+#     {
+#       second_category_id: '46',
+#       third_category: 'レンズ(ズーム)',
+#     },
+#     {
+#       second_category_id: '46',
+#       third_category: 'フィルムカメラ',
+#     },
+#     {
+#       second_category_id: '46',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '47',
+#       third_category: 'テレビ',
+#     },
+#     {
+#       second_category_id: '47',
+#       third_category: 'プロジェクター',
+#     },
+#     {
+#       second_category_id: '47',
+#       third_category: 'ブルーレイレコーダー',
+#     },
+#     {
+#       second_category_id: '47',
+#       third_category: 'DVDレコーダー',
+#     },
+#     {
+#       second_category_id: '47',
+#       third_category: 'ブルーレイプレーヤー',
+#     },
+#     {
+#       second_category_id: '47',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '48',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '49',
+#       third_category: 'クラブ',
+#     },
+#     {
+#       second_category_id: '49',
+#       third_category: 'ウェア(男性用)',
+#     },
+#     {
+#       second_category_id: '49',
+#       third_category: 'ウェア(女性用)',
+#     },
+#     {
+#       second_category_id: '49',
+#       third_category: 'バッグ',
+#     },
+#     {
+#       second_category_id: '49',
+#       third_category: 'シューズ(男性用)',
+#     },
+#     {
+#       second_category_id: '49',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '50',
+#       third_category: 'ロッド',
+#     },
+#     {
+#       second_category_id: '50',
+#       third_category: 'リール',
+#     },
+#     {
+#       second_category_id: '50',
+#       third_category: 'ルアー用品',
+#     },
+#     {
+#       second_category_id: '50',
+#       third_category: 'ウェア',
+#     },
+#     {
+#       second_category_id: '50',
+#       third_category: '釣り糸/ライン',
+#     },
+#     {
+#       second_category_id: '50',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '51',
+#       third_category: '自転車本体',
+#     },
+#     {
+#       second_category_id: '51',
+#       third_category: 'ウェア',
+#     },
+#     {
+#       second_category_id: '51',
+#       third_category: 'パーツ',
+#     },
+#     {
+#       second_category_id: '51',
+#       third_category: 'アクセサリー',
+#     },
+#     {
+#       second_category_id: '51',
+#       third_category: 'バッグ',
+#     },
+#     {
+#       second_category_id: '51',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '52',
+#       third_category: 'ランニング',
+#     },
+#     {
+#       second_category_id: '52',
+#       third_category: 'ウォーキング',
+#     },
+#     {
+#       second_category_id: '52',
+#       third_category: 'ヨガ',
+#     },
+#     {
+#       second_category_id: '52',
+#       third_category: 'トレーニング用品',
+#     },
+#     {
+#       second_category_id: '52',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '53',
+#       third_category: 'ウェア',
+#     },
+#     {
+#       second_category_id: '53',
+#       third_category: 'シューズ',
+#     },
+#     {
+#       second_category_id: '53',
+#       third_category: 'グローブ',
+#     },
+#     {
+#       second_category_id: '53',
+#       third_category: 'バット',
+#     },
+#     {
+#       second_category_id: '53',
+#       third_category: 'アクセサリー',
+#     },
+#     {
+#       second_category_id: '53',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '54',
+#       third_category: '旅行用品',
+#     },
+#     {
+#       second_category_id: '54',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '55',
+#       third_category: 'ピアス',
+#     },
+#     {
+#       second_category_id: '55',
+#       third_category: 'イヤリング',
+#     },
+#     {
+#       second_category_id: '55',
+#       third_category: 'ネックレス',
+#     },
+#     {
+#       second_category_id: '55',
+#       third_category: 'ブレスレット',
+#     },
+#     {
+#       second_category_id: '55',
+#       third_category: 'リング',
+#     },
+#     {
+#       second_category_id: '55',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '56',
+#       third_category: 'バッグ(女性用)',
+#     },
+#     {
+#       second_category_id: '56',
+#       third_category: 'バッグ(男性用)',
+#     },
+#     {
+#       second_category_id: '56',
+#       third_category: '財布(女性用)',
+#     },
+#     {
+#       second_category_id: '56',
+#       third_category: '財布(男性用)',
+#     },
+#     {
+#       second_category_id: '56',
+#       third_category: 'ファッション雑誌',
+#     },
+#     {
+#       second_category_id: '56',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '57',
+#       third_category: 'アクセサリー(男性用)',
+#     },
+#     {
+#       second_category_id: '57',
+#       third_category: '時計(女性用)',
+#     },
+#     {
+#       second_category_id: '57',
+#       third_category: '時計(男性用)',
+#     },
+#     {
+#       second_category_id: '57',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '58',
+#       third_category: 'キッチン用品',
+#     },
+#     {
+#       second_category_id: '58',
+#       third_category: '家具',
+#     },
+#     {
+#       second_category_id: '58',
+#       third_category: '文房具',
+#     },
+#     {
+#       second_category_id: '58',
+#       third_category: 'アート/写真',
+#     },
+#     {
+#       second_category_id: '58',
+#       third_category: 'アロマ/キャンドル',
+#     },
+#     {
+#       second_category_id: '58',
+#       third_category: 'その他',
+#     }, 
+#     {
+#       second_category_id: '59',
+#       third_category: 'クラフト/布製品',
+#     },
+#     {
+#       second_category_id: '59',
+#       third_category: 'おもちゃ/人形',
+#     },
+#     {
+#       second_category_id: '59',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '60',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '61',
+#       third_category: '男性アイドル',
+#     },
+#     {
+#       second_category_id: '61',
+#       third_category: '女性アイドル',
+#     },
+#     {
+#       second_category_id: '61',
+#       third_category: '韓流',
+#     },
+#     {
+#       second_category_id: '61',
+#       third_category: '国内アーティスト',
+#     },
+#     {
+#       second_category_id: '61',
+#       third_category: '海外アーティスト',
+#     },
+#     {
+#       second_category_id: '61',
+#       third_category: 'その他',
+#     }, 
+#     {
+#       second_category_id: '62',
+#       third_category: 'サッカー',
+#     },
+#     {
+#       second_category_id: '62',
+#       third_category: '野球',
+#     },
+#     {
+#       second_category_id: '62',
+#       third_category: 'テニス',
+#     },
+#     {
+#       second_category_id: '62',
+#       third_category: '格闘技/プロレス',
+#     },
+#     {
+#       second_category_id: '62',
+#       third_category: '相撲/武道',
+#     },
+#     {
+#       second_category_id: '62',
+#       third_category: 'その他',
+#     }, 
+#     {
+#       second_category_id: '63',
+#       third_category: 'ミュージカル',
+#     },
+#     {
+#       second_category_id: '63',
+#       third_category: '演劇',
+#     },
+#     {
+#       second_category_id: '63',
+#       third_category: '伝統芸能',
+#     },
+#     {
+#       second_category_id: '63',
+#       third_category: '落語',
+#     },
+#     {
+#       second_category_id: '63',
+#       third_category: 'お笑い',
+#     },
+#     {
+#       second_category_id: '63',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '64',
+#       third_category: '声優/アニメ',
+#     },
+#     {
+#       second_category_id: '64',
+#       third_category: 'キッズ/ファミリー',
+#     },
+#     {
+#       second_category_id: '64',
+#       third_category: 'トークショー/講演会',
+#     },
+#     {
+#       second_category_id: '64',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '65',
+#       third_category: '邦画',
+#     },
+#     {
+#       second_category_id: '65',
+#       third_category: '洋画',
+#     },
+#     {
+#       second_category_id: '65',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '66',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '67',
+#       third_category: '国内自動車本体',
+#     },
+#     {
+#       second_category_id: '67',
+#       third_category: '外国自動車本体',
+#     },
+#     {
+#       second_category_id: '68',
+#       third_category: 'タイヤ/ホイールセット',
+#     },
+#     {
+#       second_category_id: '68',
+#       third_category: 'タイヤ',
+#     },
+#     {
+#       second_category_id: '68',
+#       third_category: 'ホイール',
+#     },
+#     {
+#       second_category_id: '68',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '69',
+#       third_category: 'サスペンション',
+#     },
+#     {
+#       second_category_id: '69',
+#       third_category: 'ブレーキ',
+#     },
+#     {
+#       second_category_id: '69',
+#       third_category: '外装/エアロパーツ',
+#     },
+#     {
+#       second_category_id: '69',
+#       third_category: 'ライト',
+#     },
+#     {
+#       second_category_id: '69',
+#       third_category: '内装品/シート',
+#     },
+#     {
+#       second_category_id: '69',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '70',
+#       third_category: '車内アクセサリー',
+#     },
+#     {
+#       second_category_id: '70',
+#       third_category: 'カーナビ',
+#     },
+#     {
+#       second_category_id: '70',
+#       third_category: 'カーオーディオ',
+#     },
+#     {
+#       second_category_id: '70',
+#       third_category: '車外アクセサリー',
+#     },
+#     {
+#       second_category_id: '70',
+#       third_category: 'メンテナンス用品',
+#     },
+#     {
+#       second_category_id: '70',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '71',
+#       third_category: 'オートバイ本体',
+#     },
+#     {
+#       second_category_id: '72',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '73',
+#       third_category: 'まとめ売り',
+#     },
+#     {
+#       second_category_id: '74',
+#       third_category: 'ペットフード',
+#     },
+#     {
+#       second_category_id: '74',
+#       third_category: '犬用品',
+#     },
+#     {
+#       second_category_id: '74',
+#       third_category: '猫用品',
+#     },
+#     {
+#       second_category_id: '74',
+#       third_category: '魚用品/水草',
+#     },
+#     {
+#       second_category_id: '74',
+#       third_category: '小動物用品',
+#     },
+#     {
+#       second_category_id: '74',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '75',
+#       third_category: '菓子',
+#     },
+#     {
+#       second_category_id: '75',
+#       third_category: '米',
+#     },
+#     {
+#       second_category_id: '75',
+#       third_category: '野菜',
+#     },
+#     {
+#       second_category_id: '75',
+#       third_category: '果物',
+#     },
+#     {
+#       second_category_id: '75',
+#       third_category: '調味料',
+#     },
+#     {
+#       second_category_id: '75',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '76',
+#       third_category: 'コーヒー',
+#     },
+#     {
+#       second_category_id: '76',
+#       third_category: 'ソフトドリンク',
+#     },
+#     {
+#       second_category_id: '76',
+#       third_category: 'ミネラルウォーター',
+#     },
+#     {
+#       second_category_id: '76',
+#       third_category: '茶',
+#     },
+#     {
+#       second_category_id: '76',
+#       third_category: 'ウイスキー',
+#     },
+#     {
+#       second_category_id: '76',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '77',
+#       third_category: 'タオル/バス用品',
+#     },
+#     {
+#       second_category_id: '77',
+#       third_category: '日用品/生活雑貨',
+#     },
+#     {
+#       second_category_id: '77',
+#       third_category: '洗剤/柔軟剤',
+#     },
+#     {
+#       second_category_id: '77',
+#       third_category: '旅行用品',
+#     },
+#     {
+#       second_category_id: '77',
+#       third_category: '防災関連グッズ',
+#     },
+#     {
+#       second_category_id: '77',
+#       third_category: 'その他',
+#     },
+#     {
+#       second_category_id: '78',
+#       third_category: 'その他',
+#     },
+#   ]
+# )
 
-以下はカテゴリ検索の実装用の商品データです
-(1..381).each do |n|
-  third_category = ThirdCategory.find(n)
-  second_category_id = ThirdCategory.find(n)[:second_category_id]
-  second_category = SecondCategory.find(second_category_id)
-  first_category_id = SecondCategory.find(second_category_id)[:first_category_id]
-  first_category = FirstCategory.find(first_category_id)
+#以下はカテゴリ検索の実装用の商品データです
 
-  Product.create!(
-    first_category_id: first_category_id,
-    second_category_id: second_category_id,
-    third_category_id: n,
-    user_id: 1,
-    product_name: "大カテゴリ#{first_category.first_category}:中カテゴリ#{second_category.second_category}:小カテゴリ#{third_category.third_category}の商品",
-    price: 3000,
-    description: "サンプル商品です",
-    condition: "傷や汚れあり",
-    delivery_charge: "送料込み(出品者負担)",
-    delivery_date: "1~2日で発送",
-    delivery_way: "未定"
-  )
-end
+
+# (1..381).each do |n|
+#   third_category = ThirdCategory.find(n)
+#   second_category_id = ThirdCategory.find(n)[:second_category_id]
+#   second_category = SecondCategory.find(second_category_id)
+#   first_category_id = SecondCategory.find(second_category_id)[:first_category_id]
+#   first_category = FirstCategory.find(first_category_id)
+
+#   Product.create!(
+#     first_category_id: first_category_id,
+#     second_category_id: second_category_id,
+#     third_category_id: n,
+#     user_id: rand(19..26),
+#     product_name: "#{first_category.first_category}:#{second_category.second_category}:#{third_category.third_category}",
+#     price: rand(500..30000),
+#     description: "サンプル商品です",
+#     condition: "傷や汚れあり",
+#     delivery_charge: "送料込み(出品者負担)",
+#     delivery_date: "1~2日で発送",
+#     delivery_way: "未定",
+#     brand_id: 1,
+#     size_id: 1,
+#     prefecture_id: 1
+#   )
+
+#   Image.create!(
+#     product_id: n,
+#     image: File.open("./app/assets/images/mercarisampleitem4.jpg")
+#   )
+# end
 
 
 # (1..381).each do |n|


### PR DESCRIPTION
## What 
- 商品購入後に表示する、商品購入完了ページを実装した。
- 購入した商品にタグ付けを行い、再購入を不可能とした。

## Why 
- コピー元に実装されている機能であり、商品購入機能の一部として不可欠と考えたため。

<img width="753" alt="スクリーンショット 2019-08-22 12 15 35" src="https://user-images.githubusercontent.com/52557788/63483438-5b487a00-c4d7-11e9-98ff-cc176ad86d91.png">

![購入完了画面](https://user-images.githubusercontent.com/52557788/63483440-5f749780-c4d7-11e9-9f2d-9b62da69f7c7.png)
